### PR TITLE
Logging update

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -65,6 +65,7 @@ add_test(runtests runtests)
 
 install(TARGETS spectator_cpp DESTINATION lib)
 install(DIRECTORY spectator DESTINATION include FILES_MATCHING PATTERN "*.h")
+install(DIRECTORY 3rd-party/spdlog DESTINATION include FILES_MATCHING PATTERN "*.h")
 install(DIRECTORY 3rd-party/ska DESTINATION include FILES_MATCHING PATTERN "*.hpp")
 install(DIRECTORY 3rd-party/rapidjson DESTINATION include FILES_MATCHING PATTERN "*.h")
 

--- a/spectator/config.h
+++ b/spectator/config.h
@@ -7,10 +7,10 @@ namespace spectator {
 
 struct Config {
   std::map<std::string, std::string> common_tags;
-  int read_timeout; // in seconds
-  int connect_timeout; // in seconds
+  int read_timeout;     // in seconds
+  int connect_timeout;  // in seconds
   int batch_size;
-  int frequency; // in seconds
+  int frequency;  // in seconds
   std::string uri;
 };
 

--- a/spectator/logger.cc
+++ b/spectator/logger.cc
@@ -5,6 +5,8 @@
 
 namespace spectator {
 
+static constexpr const char* const kMainLogger = "spectator";
+
 LogManager& log_manager() noexcept {
   static auto* the_log_manager = new LogManager();
   return *the_log_manager;
@@ -12,18 +14,16 @@ LogManager& log_manager() noexcept {
 
 LogManager::LogManager() noexcept {
   try {
-    // use a queue with a max of 8k entries and one thread
-    spdlog::init_thread_pool(8192, 1);
-    current_logger_ =
-        spdlog::create_async_nb<spdlog::sinks::ansicolor_stdout_sink_mt>(name_);
-    current_logger_->set_level(spdlog::level::debug);
+    logger_ = spdlog::create_async_nb<spdlog::sinks::ansicolor_stdout_sink_mt>(
+        kMainLogger);
+    logger_->set_level(spdlog::level::debug);
   } catch (const spdlog::spdlog_ex& ex) {
     std::cerr << "Log initialization failed: " << ex.what() << "\n";
   }
 }
 
 std::shared_ptr<spdlog::logger> LogManager::Logger() noexcept {
-  return current_logger_;
+  return logger_;
 }
 
 }  // namespace spectator

--- a/spectator/logger.h
+++ b/spectator/logger.h
@@ -10,8 +10,7 @@ class LogManager {
   std::shared_ptr<spdlog::logger> Logger() noexcept;
 
  private:
-  std::string name_;
-  std::shared_ptr<spdlog::logger> current_logger_;
+  std::shared_ptr<spdlog::logger> logger_;
 };
 
 LogManager& log_manager() noexcept;

--- a/spectator/max_gauge.cc
+++ b/spectator/max_gauge.cc
@@ -24,7 +24,6 @@ double MaxGauge::Get() const noexcept {
     return v;
   }
   return kNaN;
-
 }
 
 void MaxGauge::Update(double value) noexcept { update_max(&value_, value); }


### PR DESCRIPTION
Use the global thread pool for logging, and avoid initializing it. Install
the spdlog library as part of our install target, letting users of this
library use it and avoid adding a duplicate which can cause problems