### PR TITLE
Minor tweaks

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -7,3 +7,4 @@ comment:
   branches: null
 ignore:
   - "3rd-party/**/*"
+  - "test/*"

--- a/run-build.sh
+++ b/run-build.sh
@@ -41,7 +41,7 @@ fi
 showinfo "Running tests ..."
 
 if [ "$CC" = gcc-5 ]; then
-  make -j4 libatlasclient_coverage
+  make -j4 spectator_cpp_coverage
 fi
 
 ./runtests

--- a/spectator/monotonic_counter.cc
+++ b/spectator/monotonic_counter.cc
@@ -5,7 +5,7 @@ namespace spectator {
 static constexpr auto kNaN = std::numeric_limits<double>::quiet_NaN();
 
 MonotonicCounter::MonotonicCounter(IdPtr id) noexcept
-    : id_{id}, value_(kNaN), prev_value_(kNaN) {}
+    : id_{std::move(id)}, value_(kNaN), prev_value_(kNaN) {}
 
 IdPtr MonotonicCounter::MeterId() const noexcept { return id_; }
 

--- a/spectator/registry.cc
+++ b/spectator/registry.cc
@@ -1,5 +1,3 @@
-#include <utility>
-
 #include "logger.h"
 #include "registry.h"
 #include <fmt/ostream.h>
@@ -46,7 +44,7 @@ std::shared_ptr<MaxGauge> Registry::GetMaxGauge(IdPtr id) noexcept {
 }
 
 std::shared_ptr<MaxGauge> Registry::GetMaxGauge(std::string name) noexcept {
-  return GetMaxGauge(CreateId(name, Tags{}));
+  return GetMaxGauge(CreateId(std::move(name), Tags{}));
 }
 
 std::shared_ptr<MonotonicCounter> Registry::GetMonotonicCounter(


### PR DESCRIPTION
Use `std::move` when possible.