### PR TITLE
Pass the logger into the registry

### DIFF
--- a/spectator/http_client.cc
+++ b/spectator/http_client.cc
@@ -126,7 +126,7 @@ int HttpClient::do_post(const std::string& url,
   curl.set_connect_timeout(connect_timeout_);
   curl.set_read_timeout(read_timeout_);
 
-  const auto& logger = Logger();
+  auto logger = registry_->GetLogger();
   logger->debug("POSTing to url: {}", url);
   curl.set_url(url);
   curl.set_headers(std::move(headers));
@@ -174,7 +174,7 @@ int HttpClient::Post(const std::string& url, const char* content_type,
   auto compress_res =
       gzip_compress(compressed_payload.get(), &compressed_size, payload, size);
   if (compress_res != Z_OK) {
-    Logger()->error(
+    registry_->GetLogger()->error(
         "Failed to compress payload: {}, while posting to {} - uncompressed "
         "size: {}",
         compress_res, url, size);

--- a/spectator/logger.h
+++ b/spectator/logger.h
@@ -15,7 +15,7 @@ class LogManager {
 
 LogManager& log_manager() noexcept;
 
-inline std::shared_ptr<spdlog::logger> Logger() noexcept {
+inline std::shared_ptr<spdlog::logger> DefaultLogger() noexcept {
   return log_manager().Logger();
 }
 

--- a/spectator/registry.cc
+++ b/spectator/registry.cc
@@ -4,10 +4,14 @@
 
 namespace spectator {
 
-Registry::Registry(Config config) noexcept
-    : config_{std::move(config)}, publisher_(this) {}
+Registry::Registry(Config config, Registry::logger_ptr logger) noexcept
+    : config_{std::move(config)},
+      logger_{std::move(logger)},
+      publisher_(this) {}
 
 const Config& Registry::GetConfig() const noexcept { return config_; }
+
+Registry::logger_ptr Registry::GetLogger() const noexcept { return logger_; }
 
 IdPtr Registry::CreateId(std::string name, Tags tags) noexcept {
   return std::make_shared<Id>(name, tags);
@@ -76,7 +80,7 @@ std::shared_ptr<Meter> Registry::insert_if_needed(
 
 void Registry::log_type_error(const Id& id, MeterType prev_type,
                               MeterType attempted_type) const noexcept {
-  Logger()->error(
+  logger_->error(
       "Attempted to register meter {} as type {} but previously registered as "
       "{}",
       id, attempted_type, prev_type);

--- a/spectator/registry.h
+++ b/spectator/registry.h
@@ -15,9 +15,11 @@ namespace spectator {
 class Registry {
  public:
   using clock = std::chrono::steady_clock;
+  using logger_ptr = std::shared_ptr<spdlog::logger>;
 
-  explicit Registry(Config config) noexcept;
+  Registry(Config config, logger_ptr logger) noexcept;
   const Config& GetConfig() const noexcept;
+  logger_ptr GetLogger() const noexcept;
 
   IdPtr CreateId(std::string name, Tags tags) noexcept;
 
@@ -50,6 +52,7 @@ class Registry {
 
  private:
   Config config_;
+  logger_ptr logger_;
   mutable std::mutex meters_mutex{};
   ska::flat_hash_map<IdPtr, std::shared_ptr<Meter>> meters_;
 

--- a/test/http_client_test.cc
+++ b/test/http_client_test.cc
@@ -16,9 +16,9 @@
 #include <thread>
 
 using spectator::Config;
+using spectator::DefaultLogger;
 using spectator::gzip_uncompress;
 using spectator::HttpClient;
-using spectator::Logger;
 using spectator::Registry;
 using spectator::Tags;
 
@@ -43,7 +43,7 @@ class TestClock {};
 class TestRegistry : public Registry {
  public:
   using clock = TestClock;
-  TestRegistry(Config config) : Registry(std::move(config)) {}
+  TestRegistry(Config config) : Registry(std::move(config), DefaultLogger()) {}
 };
 
 TEST(HttpTest, Post) {
@@ -52,7 +52,7 @@ TEST(HttpTest, Post) {
 
   auto port = server.get_port();
   ASSERT_TRUE(port > 0) << "Port = " << port;
-  auto logger = Logger();
+  auto logger = DefaultLogger();
   logger->info("Server started on port {}", port);
 
   TestRegistry registry{Config{}};
@@ -100,10 +100,10 @@ TEST(HttpTest, Timeout) {
 
   auto port = server.get_port();
   ASSERT_TRUE(port > 0) << "Port = " << port;
-  auto logger = Logger();
+  TestRegistry registry{Config{}};
+  auto logger = registry.GetLogger();
   logger->info("Server started on port {}", port);
 
-  TestRegistry registry{Config{}};
   HttpClient client{&registry, 1, 1};
   auto url = fmt::format("http://localhost:{}/foo", port);
   const std::string post_data = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";

--- a/test/http_server.cc
+++ b/test/http_server.cc
@@ -8,8 +8,8 @@
 #include <sys/socket.h>
 #include <thread>
 
+using spectator::DefaultLogger;
 using spectator::gzip_compress;
-using spectator::Logger;
 
 http_server::http_server() noexcept {
   path_response_["/foo"] =
@@ -157,7 +157,7 @@ void http_server::accept_request(int client) {
     p += bytes_read;
   }
   *p = '\0';
-  Logger()->debug("Adding request {} {}", method, path);
+  DefaultLogger()->debug("Adding request {} {}", method, path);
   {
     std::lock_guard<std::mutex> guard(requests_mutex_);
     requests_.emplace_back(method, path, headers, content_len, std::move(body));

--- a/test/publisher_test.cc
+++ b/test/publisher_test.cc
@@ -5,6 +5,7 @@
 #include <rapidjson/writer.h>
 
 using spectator::Config;
+using spectator::DefaultLogger;
 using spectator::Measurement;
 using spectator::Publisher;
 using spectator::Registry;
@@ -15,7 +16,7 @@ class TestClock {};
 class TestRegistry : public Registry {
  public:
   using clock = TestClock;
-  TestRegistry(Config config) : Registry(std::move(config)) {}
+  TestRegistry(Config config) : Registry(std::move(config), DefaultLogger()) {}
 };
 
 class TestPublisher : public Publisher<TestRegistry> {

--- a/test/registry_test.cc
+++ b/test/registry_test.cc
@@ -4,45 +4,46 @@
 
 namespace {
 using spectator::Config;
+using spectator::DefaultLogger;
 using spectator::Registry;
 
 TEST(Registry, Counter) {
-  Registry r{Config{}};
+  Registry r{Config{}, DefaultLogger()};
   auto c = r.GetCounter("foo");
   c->Increment();
   EXPECT_EQ(c->Count(), 1);
 }
 
 TEST(Registry, CounterGet) {
-  Registry r{Config{}};
+  Registry r{Config{}, DefaultLogger()};
   auto c = r.GetCounter("foo");
   c->Increment();
   EXPECT_EQ(r.GetCounter("foo")->Count(), 1);
 }
 
 TEST(Registry, DistSummary) {
-  Registry r{Config{}};
+  Registry r{Config{}, DefaultLogger()};
   auto ds = r.GetDistributionSummary("ds");
   ds->Record(100);
   EXPECT_EQ(r.GetDistributionSummary("ds")->TotalAmount(), 100);
 }
 
 TEST(Registry, Gauge) {
-  Registry r{Config{}};
+  Registry r{Config{}, DefaultLogger()};
   auto g = r.GetGauge("g");
   g->Set(100);
   EXPECT_DOUBLE_EQ(r.GetGauge("g")->Get(), 100);
 }
 
 TEST(Registry, MaxGauge) {
-  Registry r{Config{}};
+  Registry r{Config{}, DefaultLogger()};
   auto g = r.GetMaxGauge("g");
   g->Update(100);
   EXPECT_DOUBLE_EQ(r.GetMaxGauge("g")->Get(), 100);
 }
 
 TEST(Registry, MonotonicCounter) {
-  Registry r{Config{}};
+  Registry r{Config{}, DefaultLogger()};
   auto c = r.GetMonotonicCounter("m");
   c->Set(100);
   c->Measure();
@@ -51,14 +52,14 @@ TEST(Registry, MonotonicCounter) {
 }
 
 TEST(Registry, Timer) {
-  Registry r{Config{}};
+  Registry r{Config{}, DefaultLogger()};
   auto t = r.GetTimer("t");
   t->Record(std::chrono::microseconds(1));
   EXPECT_EQ(r.GetTimer("t")->TotalTime(), 1000);
 }
 
 TEST(Registry, WrongType) {
-  Registry r{Config{}};
+  Registry r{Config{}, DefaultLogger()};
   auto t = r.GetTimer("meter");
   t->Record(std::chrono::nanoseconds(1));
 
@@ -74,7 +75,7 @@ TEST(Registry, WrongType) {
 }
 
 TEST(Registry, Meters) {
-  Registry r{Config{}};
+  Registry r{Config{}, DefaultLogger()};
   auto t = r.GetTimer("t");
   auto c = r.GetCounter("c");
   r.GetTimer("t")->Count();
@@ -83,7 +84,7 @@ TEST(Registry, Meters) {
 }
 
 TEST(Registry, MeasurementTest) {
-  Registry r{Config{}};
+  Registry r{Config{}, DefaultLogger()};
   auto c = r.GetCounter("c");
   c->Increment();
   auto m = c->Measure().front();


### PR DESCRIPTION
This will allow clients to have control of the logger, and should keep
the code itself simple. It's a first step to dealing with #7 