### PR TITLE
Rename the build directory to avoid conflicts

### DIFF
--- a/create-lcov-report.sh
+++ b/create-lcov-report.sh
@@ -6,7 +6,7 @@ fi
 echo $PWD
 # capture coverage info
 lcov --directory . --capture --output-file coverage.info
-# filter out system, build, tests and 3rd-party code from our test coverage
-lcov --remove coverage.info '/usr/*' '*/usr/*' '*/3rd-party/*' '*/build/*' '*/test/*' --output-file coverage.info
+# filter out system, cmake-build, tests and 3rd-party code from our test coverage
+lcov --remove coverage.info '/usr/*' '*/usr/*' '*/3rd-party/*' '*/cmake-build/*' '*/test/*' --output-file coverage.info
 # print report to stdout for debugging
 lcov --list coverage.info

--- a/run-build.sh
+++ b/run-build.sh
@@ -13,8 +13,8 @@ workingprocess() { echo -e "${BB}$1${NC}"; }
 allert () { echo -e "${RED}$1${NC}"; }
 
 # Building project
-mkdir -p build
-cd build
+mkdir -p cmake-build
+cd cmake-build
 
 if [ "$CC" = gcc ] ; then
   export CC=gcc-5


### PR DESCRIPTION
Case insensitive file systems were failing the build due to the presence
of the BUILD file for bazel.