### PR TITLE
Add a hook to disable/enable publishing of metrics

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -49,7 +49,7 @@ if(CMAKE_SYSTEM_NAME STREQUAL Linux)
 else()
   configure_file(${CMAKE_SOURCE_DIR}/bundle/libcurl-osx.a libcurl.a COPYONLY)
 endif()
-target_link_libraries(spectator_cpp ${CMAKE_BINARY_DIR}/libcurl.a z )
+target_link_libraries(spectator_cpp ${CMAKE_BINARY_DIR}/libcurl.a z)
 
 # test configuration
 enable_testing()

--- a/spectator/config.h
+++ b/spectator/config.h
@@ -5,13 +5,27 @@
 
 namespace spectator {
 
-struct Config {
+class Config {
+ public:
+  virtual ~Config() = default;
+  Config() = default;
+  Config(const Config&) = default;
+
+  Config(std::map<std::string, std::string> c_tags, int read_to, int connect_to,
+         int batch_sz, int freq, std::string publish_uri)
+      : common_tags{std::move(c_tags)},
+        read_timeout{read_to},
+        connect_timeout{connect_to},
+        batch_size{batch_sz},
+        frequency{freq},
+        uri{std::move(publish_uri)} {}
   std::map<std::string, std::string> common_tags;
   int read_timeout;     // in seconds
   int connect_timeout;  // in seconds
   int batch_size;
   int frequency;  // in seconds
   std::string uri;
+  virtual bool is_enabled() const { return true; }
 };
 
 }  // namespace spectator

--- a/spectator/publisher.h
+++ b/spectator/publisher.h
@@ -214,6 +214,9 @@ class Publisher {
     auto batch_size =
         static_cast<std::vector<Measurement>::difference_type>(cfg.batch_size);
     auto measurements = registry_->Measurements();
+    if (!cfg.is_enabled()) {
+      return std::make_pair(0, 0);
+    }
     std::vector<rapidjson::Document> batches;
 
     auto from = measurements.begin();

--- a/test/config_test.cc
+++ b/test/config_test.cc
@@ -1,0 +1,13 @@
+#include "../spectator/config.h"
+#include "../spectator/registry.h"
+#include <gtest/gtest.h>
+
+TEST(Config, Constructor) {
+  std::map<std::string, std::string> common_tags{};
+  static constexpr auto kDefault = 0;
+
+  // just make sure that our documented Config constructor works
+  spectator::Config config{common_tags, kDefault,
+                           kDefault,    kDefault,
+                           kDefault,    "http://example.org/api/v1/publish"};
+}


### PR DESCRIPTION
We have some use cases where we want to avoid publishing metrics under
certain conditions. Convert the Config struct into a class, and add an
is_enabled method that can be overriden as needed. Note that the
measurements are still taken (which will cause the meters to be reset)