### PR TITLE
Use pointers to Config so virtual methods work

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,11 +70,7 @@ Request get_next_request() {
 }
 
 int main() {
-  std::map<std::string, std::string> common_tags = {{"nf.app", "example"},
-                                                    {"nf.region", "us-west-1"}};
-  spectator::Config config{common_tags, kDefault, kDefault,
-                           kDefault,    kDefault, "http://example.org/api/v1/publish"};
-  spectator::Registry registry{config};
+  spectator::Registry registry{spectator::GetConfiguration()};
 
   registry.Start();
 

--- a/spectator/config.h
+++ b/spectator/config.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <map>
+#include <memory>
 #include <string>
 
 namespace spectator {
@@ -25,7 +26,13 @@ class Config {
   int batch_size;
   int frequency;  // in seconds
   std::string uri;
+
+  // sub-classes can override this method implementing custom logic
+  // that can disable publishing under certain conditions
   virtual bool is_enabled() const { return true; }
 };
+
+// Get a new spectator configuration.
+std::unique_ptr<Config> GetConfiguration();
 
 }  // namespace spectator

--- a/spectator/registry.cc
+++ b/spectator/registry.cc
@@ -4,12 +4,13 @@
 
 namespace spectator {
 
-Registry::Registry(Config config, Registry::logger_ptr logger) noexcept
+Registry::Registry(std::unique_ptr<Config> config,
+                   Registry::logger_ptr logger) noexcept
     : config_{std::move(config)},
       logger_{std::move(logger)},
       publisher_(this) {}
 
-const Config& Registry::GetConfig() const noexcept { return config_; }
+const Config& Registry::GetConfig() const noexcept { return *config_; }
 
 Registry::logger_ptr Registry::GetLogger() const noexcept { return logger_; }
 

--- a/spectator/registry.h
+++ b/spectator/registry.h
@@ -17,7 +17,7 @@ class Registry {
   using clock = std::chrono::steady_clock;
   using logger_ptr = std::shared_ptr<spdlog::logger>;
 
-  Registry(Config config, logger_ptr logger) noexcept;
+  Registry(std::unique_ptr<Config> config, logger_ptr logger) noexcept;
   const Config& GetConfig() const noexcept;
   logger_ptr GetLogger() const noexcept;
 
@@ -51,7 +51,7 @@ class Registry {
   void Stop() noexcept;
 
  private:
-  Config config_;
+  std::unique_ptr<Config> config_;
   logger_ptr logger_;
   mutable std::mutex meters_mutex{};
   ska::flat_hash_map<IdPtr, std::shared_ptr<Meter>> meters_;

--- a/spectator/sample_config.cc
+++ b/spectator/sample_config.cc
@@ -1,0 +1,10 @@
+#include "config.h"
+#include "memory.h"
+
+namespace spectator {
+
+std::unique_ptr<Config> GetConfiguration() {
+  return std::make_unique<Config>();
+}
+
+}  // namespace spectator

--- a/test/http_client_test.cc
+++ b/test/http_client_test.cc
@@ -17,6 +17,7 @@
 
 using spectator::Config;
 using spectator::DefaultLogger;
+using spectator::GetConfiguration;
 using spectator::gzip_uncompress;
 using spectator::HttpClient;
 using spectator::Registry;
@@ -43,7 +44,8 @@ class TestClock {};
 class TestRegistry : public Registry {
  public:
   using clock = TestClock;
-  TestRegistry(Config config) : Registry(std::move(config), DefaultLogger()) {}
+  TestRegistry(std::unique_ptr<Config> config)
+      : Registry(std::move(config), DefaultLogger()) {}
 };
 
 TEST(HttpTest, Post) {
@@ -55,7 +57,7 @@ TEST(HttpTest, Post) {
   auto logger = DefaultLogger();
   logger->info("Server started on port {}", port);
 
-  TestRegistry registry{Config{}};
+  TestRegistry registry{GetConfiguration()};
   HttpClient client{&registry, 100, 100};
   auto url = fmt::format("http://localhost:{}/foo", port);
   const std::string post_data = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
@@ -100,7 +102,7 @@ TEST(HttpTest, Timeout) {
 
   auto port = server.get_port();
   ASSERT_TRUE(port > 0) << "Port = " << port;
-  TestRegistry registry{Config{}};
+  TestRegistry registry{GetConfiguration()};
   auto logger = registry.GetLogger();
   logger->info("Server started on port {}", port);
 

--- a/test/publisher_test.cc
+++ b/test/publisher_test.cc
@@ -16,7 +16,8 @@ class TestClock {};
 class TestRegistry : public Registry {
  public:
   using clock = TestClock;
-  TestRegistry(Config config) : Registry(std::move(config), DefaultLogger()) {}
+  TestRegistry(std::unique_ptr<Config> config)
+      : Registry(std::move(config), DefaultLogger()) {}
 };
 
 class TestPublisher : public Publisher<TestRegistry> {
@@ -31,10 +32,10 @@ class TestPublisher : public Publisher<TestRegistry> {
   }
 };
 
-Config get_test_config() {
-  Config config{};
-  config.common_tags["app"] = "atlas";
-  config.common_tags["node"] = "i-1234";
+std::unique_ptr<Config> get_test_config() {
+  auto config = spectator::GetConfiguration();
+  config->common_tags["app"] = "atlas";
+  config->common_tags["node"] = "i-1234";
   return config;
 }
 

--- a/test/registry_test.cc
+++ b/test/registry_test.cc
@@ -3,47 +3,47 @@
 #include <gtest/gtest.h>
 
 namespace {
-using spectator::Config;
 using spectator::DefaultLogger;
+using spectator::GetConfiguration;
 using spectator::Registry;
 
 TEST(Registry, Counter) {
-  Registry r{Config{}, DefaultLogger()};
+  Registry r{GetConfiguration(), DefaultLogger()};
   auto c = r.GetCounter("foo");
   c->Increment();
   EXPECT_EQ(c->Count(), 1);
 }
 
 TEST(Registry, CounterGet) {
-  Registry r{Config{}, DefaultLogger()};
+  Registry r{GetConfiguration(), DefaultLogger()};
   auto c = r.GetCounter("foo");
   c->Increment();
   EXPECT_EQ(r.GetCounter("foo")->Count(), 1);
 }
 
 TEST(Registry, DistSummary) {
-  Registry r{Config{}, DefaultLogger()};
+  Registry r{GetConfiguration(), DefaultLogger()};
   auto ds = r.GetDistributionSummary("ds");
   ds->Record(100);
   EXPECT_EQ(r.GetDistributionSummary("ds")->TotalAmount(), 100);
 }
 
 TEST(Registry, Gauge) {
-  Registry r{Config{}, DefaultLogger()};
+  Registry r{GetConfiguration(), DefaultLogger()};
   auto g = r.GetGauge("g");
   g->Set(100);
   EXPECT_DOUBLE_EQ(r.GetGauge("g")->Get(), 100);
 }
 
 TEST(Registry, MaxGauge) {
-  Registry r{Config{}, DefaultLogger()};
+  Registry r{GetConfiguration(), DefaultLogger()};
   auto g = r.GetMaxGauge("g");
   g->Update(100);
   EXPECT_DOUBLE_EQ(r.GetMaxGauge("g")->Get(), 100);
 }
 
 TEST(Registry, MonotonicCounter) {
-  Registry r{Config{}, DefaultLogger()};
+  Registry r{GetConfiguration(), DefaultLogger()};
   auto c = r.GetMonotonicCounter("m");
   c->Set(100);
   c->Measure();
@@ -52,14 +52,14 @@ TEST(Registry, MonotonicCounter) {
 }
 
 TEST(Registry, Timer) {
-  Registry r{Config{}, DefaultLogger()};
+  Registry r{GetConfiguration(), DefaultLogger()};
   auto t = r.GetTimer("t");
   t->Record(std::chrono::microseconds(1));
   EXPECT_EQ(r.GetTimer("t")->TotalTime(), 1000);
 }
 
 TEST(Registry, WrongType) {
-  Registry r{Config{}, DefaultLogger()};
+  Registry r{GetConfiguration(), DefaultLogger()};
   auto t = r.GetTimer("meter");
   t->Record(std::chrono::nanoseconds(1));
 
@@ -75,7 +75,7 @@ TEST(Registry, WrongType) {
 }
 
 TEST(Registry, Meters) {
-  Registry r{Config{}, DefaultLogger()};
+  Registry r{GetConfiguration(), DefaultLogger()};
   auto t = r.GetTimer("t");
   auto c = r.GetCounter("c");
   r.GetTimer("t")->Count();
@@ -84,7 +84,7 @@ TEST(Registry, Meters) {
 }
 
 TEST(Registry, MeasurementTest) {
-  Registry r{Config{}, DefaultLogger()};
+  Registry r{GetConfiguration(), DefaultLogger()};
   auto c = r.GetCounter("c");
   c->Increment();
   auto m = c->Measure().front();


### PR DESCRIPTION
This breaks the API but is needed to make overriding the functionality
in the Config class possible