### PR TITLE
Report the max statistic for timers in seconds

### DIFF
--- a/spectator/timer.cc
+++ b/spectator/timer.cc
@@ -20,11 +20,12 @@ std::vector<Measurement> Timer::Measure() const noexcept {
   auto t_sq = totalSq_.exchange(0.0, std::memory_order_relaxed);
   auto t_sq_secs = t_sq / 1e18;
   auto mx = max_.exchange(0, std::memory_order_relaxed);
+  auto mx_secs = mx / 1e9;
   results.reserve(4);
   results.push_back({id_->WithStat("count"), static_cast<double>(cnt)});
   results.push_back({id_->WithStat("totalTime"), total_secs});
   results.push_back({id_->WithStat("totalOfSquares"), t_sq_secs});
-  results.push_back({id_->WithStat("max"), static_cast<double>(mx)});
+  results.push_back({id_->WithStat("max"), mx_secs});
   return results;
 }
 

--- a/test/timer_test.cc
+++ b/test/timer_test.cc
@@ -45,7 +45,7 @@ void expect_timer(const Timer& t, int64_t count, int64_t total, double total_sq,
   expected[id->WithStat("count")] = count;
   expected[id->WithStat("totalTime")] = total / 1e9;
   expected[id->WithStat("totalOfSquares")] = total_sq / 1e18;
-  expected[id->WithStat("max")] = max;
+  expected[id->WithStat("max")] = max / 1e9;
 
   for (const auto& m : ms) {
     auto it = expected.find(m.id);


### PR DESCRIPTION
We were incorrectly reporting the max statistic in nanoseconds instead
of seconds