### PR TITLE
Support for percentile timers and dist summaries

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -35,10 +35,26 @@ endif()
 
 set(CMAKE_POSITION_INDEPENDENT_CODE ON)
 
-file(GLOB LIB_SOURCE_FILES spectator/*.h spectator/*.cc)
-add_library(spectator_cpp SHARED ${LIB_SOURCE_FILES})
-set_target_properties(spectator_cpp PROPERTIES COMPILE_FLAGS "-Wextra -Wno-missing-braces")
+add_executable(gen_perc_bucket_tags ./gen_perc_bucket_tags.cc)
+add_executable(gen_perc_bucket_values ./gen_perc_bucket_values.cc)
 
+# add the commands to generate the include files
+add_custom_command (
+        OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/percentile_bucket_tags.inc
+        COMMAND gen_perc_bucket_tags ${CMAKE_CURRENT_BINARY_DIR}/percentile_bucket_tags.inc
+        DEPENDS gen_perc_bucket_tags
+)
+add_custom_command (
+        OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/percentile_bucket_values.inc
+        COMMAND gen_perc_bucket_values ${CMAKE_CURRENT_BINARY_DIR}/percentile_bucket_values.inc
+        DEPENDS gen_perc_bucket_values
+)
+
+file(GLOB LIB_SOURCE_FILES spectator/*.h spectator/*.cc)
+add_library(spectator_cpp SHARED ${LIB_SOURCE_FILES}
+        ${CMAKE_CURRENT_BINARY_DIR}/percentile_bucket_tags.inc
+        ${CMAKE_CURRENT_BINARY_DIR}/percentile_bucket_values.inc)
+set_target_properties(spectator_cpp PROPERTIES COMPILE_FLAGS "-Wextra -Wno-missing-braces")
 
 if(CMAKE_SYSTEM_NAME STREQUAL Linux)
   configure_file(${CMAKE_SOURCE_DIR}/bundle/libcurl-linux.a libcurl.a COPYONLY)

--- a/gen_perc_bucket_tags.cc
+++ b/gen_perc_bucket_tags.cc
@@ -1,0 +1,34 @@
+#include <fstream>
+#include <vector>
+
+// Number of positions of base-2 digits to shift when iterating over the long
+// space.
+void output_array(std::ostream& os, size_t size, char prefix,
+                  const std::string& name) {
+  os << "const std::array<std::string, 276>"
+     << " " << name << " = {{";
+  bool first = true;
+  char tag[64];
+  for (size_t i = 0; i < size; ++i) {
+    if (!first) {
+      os << ",\n";
+    } else {
+      first = false;
+    }
+    sprintf(tag, "\"%c%04zX\"", prefix, i);
+    os << tag;
+  }
+  os << "}};\n";
+}
+
+int main(int argc, char* argv[]) {
+  std::ofstream of;
+  if (argc > 1) {
+    of.open(argv[1]);
+  } else {
+    of.open("/dev/stdout");
+  }
+
+  output_array(of, 276, 'T', "kTimerTags");
+  output_array(of, 276, 'D', "kDistTags");
+}

--- a/gen_perc_bucket_values.cc
+++ b/gen_perc_bucket_values.cc
@@ -1,0 +1,68 @@
+#include <fstream>
+#include <limits>
+#include <vector>
+
+// Number of positions of base-2 digits to shift when iterating over the long
+// space.
+constexpr int kDigits = 2;
+
+static std::vector<int64_t> bucketValues;
+static std::vector<size_t> powerOf4Index;
+
+static void init() {
+  powerOf4Index.push_back(0);
+  bucketValues.push_back(1);
+  bucketValues.push_back(2);
+  bucketValues.push_back(3);
+
+  auto exp = kDigits;
+  while (exp < 64) {
+    auto current = int64_t{1} << exp;
+    auto delta = current / 3;
+    auto next = (current << kDigits) - delta;
+
+    powerOf4Index.push_back(bucketValues.size());
+    while (current < next) {
+      bucketValues.push_back(current);
+      current += delta;
+    }
+    exp += kDigits;
+  }
+  bucketValues.push_back(std::numeric_limits<int64_t>::max());
+}
+
+int main(int argc, char* argv[]) {
+  init();
+  std::ofstream of;
+  if (argc > 1) {
+    of.open(argv[1]);
+  } else {
+    of.open("/dev/stdout");
+  }
+  of << "// Do not modify - auto-generated\n//\n"
+     << "const std::array<int64_t, " << bucketValues.size()
+     << "> kBucketValues = {{";
+  bool first = true;
+  for (auto v : bucketValues) {
+    if (!first) {
+      of << ",\n";
+    } else {
+      first = false;
+    }
+    of << "  " << v << "LL";
+  }
+  of << "}};\n";
+
+  of << "const std::array<size_t, " << powerOf4Index.size()
+     << "> kPowerOf4Index = {{\n";
+  first = true;
+  for (auto v : powerOf4Index) {
+    if (!first) {
+      of << ",\n";
+    } else {
+      first = false;
+    }
+    of << "  " << v << "u";
+  }
+  of << "\n}};\n";
+}

--- a/spectator/counter.cc
+++ b/spectator/counter.cc
@@ -10,7 +10,8 @@ IdPtr Counter::MeterId() const noexcept { return id_; }
 std::vector<Measurement> Counter::Measure() const noexcept {
   auto count = count_.exchange(0.0, std::memory_order_relaxed);
   if (count > 0) {
-    return std::vector<Measurement>({{id_->WithStat("count"), count}});
+    return std::vector<Measurement>(
+        {{Id::WithDefaultStat(id_, "count"), count}});
   }
   return std::vector<Measurement>();
 }

--- a/spectator/id.h
+++ b/spectator/id.h
@@ -39,9 +39,9 @@ class Tags {
 
   bool operator==(const Tags& that) const { return that.entries_ == entries_; }
 
-  bool has(K key) const { return entries_.find(key) != entries_.end(); }
+  bool has(const K& key) const { return entries_.find(key) != entries_.end(); }
 
-  K at(K key) const {
+  K at(const K& key) const {
     auto entry = entries_.find(key);
     if (entry != entries_.end()) {
       return entry->second;
@@ -73,6 +73,15 @@ class Id {
   std::unique_ptr<Id> WithStat(const std::string& stat) const {
     return WithTag("statistic", stat);
   };
+
+  static std::shared_ptr<Id> WithDefaultStat(std::shared_ptr<Id> baseId,
+                                             const std::string& stat) {
+    if (baseId->GetTags().has("statistic")) {
+      return baseId;
+    } else {
+      return baseId->WithStat(stat);
+    }
+  }
 
   friend std::ostream& operator<<(std::ostream& os, const Id& id);
 

--- a/spectator/meter.h
+++ b/spectator/meter.h
@@ -41,7 +41,7 @@ inline std::ostream& operator<<(std::ostream& os, const MeterType& mt) {
 
 class Meter {
  public:
-  virtual ~Meter(){};
+  virtual ~Meter() = default;
   virtual IdPtr MeterId() const noexcept = 0;
   virtual std::vector<Measurement> Measure() const noexcept = 0;
   virtual MeterType GetType() const noexcept = 0;

--- a/spectator/percentile_buckets.cc
+++ b/spectator/percentile_buckets.cc
@@ -1,0 +1,86 @@
+#include "percentile_buckets.h"
+#include <limits>
+
+namespace spectator {
+
+#include "percentile_bucket_values.inc"
+
+int64_t GetPercBucketValue(size_t i) { return kBucketValues.at(i); }
+
+size_t PercentileBucketIndexOf(int64_t v) {
+  if (v <= 0) {
+    return 0;
+  }
+  if (v <= 4) {
+    return static_cast<size_t>(v);
+  }
+  size_t lz = __builtin_clzll(v);
+  size_t shift = 64 - lz - 1;
+  int64_t prevPowerOf2 = (v >> shift) << shift;
+  int64_t prevPowerOf4 = prevPowerOf2;
+  if (shift % 2 != 0) {
+    --shift;
+    prevPowerOf4 >>= 1;
+  }
+
+  auto base = prevPowerOf4;
+  auto delta = base / 3;
+  auto offset = static_cast<size_t>((v - base) / delta);
+  size_t pos = offset + kPowerOf4Index.at(shift / 2);
+  return pos >= kBucketValues.size() - 1 ? kBucketValues.size() - 1 : pos + 1;
+}
+
+void Percentiles(const std::array<int64_t, PercentileBucketsLength()>& counts,
+                 const std::vector<double>& pcts,
+                 std::vector<double>* results) {
+  int64_t total = 0;
+  for (size_t i = 0; i < kBucketValues.size(); ++i) {
+    total += counts.at(i);
+  }
+
+  size_t pctIdx = 0;
+  int64_t prev = 0;
+  auto prevP = 0.0;
+  int64_t prevB = 0;
+  results->clear();
+  results->resize(pcts.size());
+
+  for (size_t i = 0; i < kBucketValues.size(); ++i) {
+    auto next = prev + counts.at(i);
+    auto nextP = 100.0 * next / total;
+    auto nextB = kBucketValues.at(i);
+    while (pctIdx < pcts.size() && nextP >= pcts[pctIdx]) {
+      auto f = (pcts[pctIdx] - prevP) / (nextP - prevP);
+      results->at(pctIdx) = f * (nextB - prevB) + prevB;
+      ++pctIdx;
+    }
+    if (pctIdx >= pcts.size()) {
+      break;
+    }
+    prev = next;
+    prevP = nextP;
+    prevB = nextB;
+  }
+
+  auto nextP = 100.0;
+  auto nextB = std::numeric_limits<int64_t>::max();
+  while (pctIdx < pcts.size()) {
+    auto f = (pcts[pctIdx] - prevP) / (nextP - prevP);
+    results->at(pctIdx) = f * (nextB - prevB) + prevB;
+    ++pctIdx;
+  }
+}
+
+double Percentile(const std::array<int64_t, PercentileBucketsLength()>& counts,
+                  double p) {
+  std::vector<double> pcts{p};
+  std::vector<double> results;
+  Percentiles(counts, pcts, &results);
+  return results[0];
+}
+
+int64_t PercentileBucket(int64_t v) {
+  return GetPercBucketValue(PercentileBucketIndexOf(v));
+}
+
+}  // namespace spectator

--- a/spectator/percentile_buckets.h
+++ b/spectator/percentile_buckets.h
@@ -1,0 +1,31 @@
+#pragma once
+
+#include <array>
+#include <cstdint>
+#include <cstddef>
+#include <vector>
+
+namespace spectator {
+
+int64_t PercentileBucket(int64_t v);
+size_t PercentileBucketIndexOf(int64_t v);
+constexpr size_t PercentileBucketsLength() { return 276; }
+double Percentile(const std::array<int64_t, PercentileBucketsLength()>& counts,
+                  double p);
+///
+/// Compute a set of percentiles based on the counts for the buckets.
+///
+/// @param counts
+///     Counts for each of the buckets.
+///     positions must correspond to the positions of the bucket values.
+/// @param pcts
+///     Vector with the requested percentile values. The length must be at least
+///     1 and the
+///     array should be sorted. Each value, {@code v}, should adhere to {@code
+///     0.0 <= v <= 100.0}.
+/// @param results
+///     The calculated percentile values will be written to the results vector.
+void Percentiles(const std::array<int64_t, PercentileBucketsLength()>& counts,
+                 const std::vector<double>& pcts, std::vector<double>* results);
+
+}  // namespace spectator

--- a/spectator/percentile_distribution_summary.cc
+++ b/spectator/percentile_distribution_summary.cc
@@ -1,0 +1,38 @@
+#include "percentile_distribution_summary.h"
+#include "percentile_bucket_tags.inc"
+
+using nanos = std::chrono::nanoseconds;
+
+namespace spectator {
+
+PercentileDistributionSummary::PercentileDistributionSummary(
+    spectator::Registry* registry, spectator::IdPtr id) noexcept
+    : registry_{registry},
+      id_{std::move(id)},
+      dist_summary_{registry->GetDistributionSummary(id_)} {}
+
+void PercentileDistributionSummary::Record(int64_t amount) noexcept {
+  dist_summary_->Record(amount);
+  auto index = PercentileBucketIndexOf(amount);
+  auto& c = counters_.at(index);
+  if (!c) {
+    auto counterId =
+        id_->WithStat("percentile")->WithTag("percentile", kDistTags.at(index));
+    counters_.at(index) = registry_->GetCounter(std::move(counterId));
+    c = counters_.at(index);
+  }
+  c->Increment();
+}
+
+double PercentileDistributionSummary::Percentile(double p) const noexcept {
+  std::array<int64_t, PercentileBucketsLength()> counts{};
+  for (size_t i = 0; i < PercentileBucketsLength(); ++i) {
+    auto& c = counters_.at(i);
+    if (c) {
+      counts.at(i) = c->Count();
+    }
+  }
+  return spectator::Percentile(counts, p);
+}
+
+}  // namespace spectator

--- a/spectator/percentile_distribution_summary.h
+++ b/spectator/percentile_distribution_summary.h
@@ -1,0 +1,26 @@
+#pragma once
+
+#include <chrono>
+#include "id.h"
+#include "registry.h"
+#include "percentile_buckets.h"
+namespace spectator {
+
+class PercentileDistributionSummary {
+ public:
+  PercentileDistributionSummary(Registry* registry, IdPtr id) noexcept;
+
+  void Record(int64_t amount) noexcept;
+  int64_t Count() const noexcept { return dist_summary_->Count(); }
+  double TotalAmount() const noexcept { return dist_summary_->TotalAmount(); }
+  double Percentile(double p) const noexcept;
+
+ private:
+  Registry* registry_;
+  IdPtr id_;
+  std::shared_ptr<DistributionSummary> dist_summary_;
+  mutable std::array<std::shared_ptr<Counter>, PercentileBucketsLength()>
+      counters_{};
+};
+
+}  // namespace spectator

--- a/spectator/percentile_timer.cc
+++ b/spectator/percentile_timer.cc
@@ -1,0 +1,54 @@
+#include "percentile_timer.h"
+#include "percentile_bucket_tags.inc"
+
+using nanos = std::chrono::nanoseconds;
+
+namespace spectator {
+
+PercentileTimer::PercentileTimer(spectator::Registry* registry,
+                                 spectator::IdPtr id,
+                                 std::chrono::nanoseconds min,
+                                 std::chrono::nanoseconds max) noexcept
+    : registry_{registry},
+      id_{std::move(id)},
+      min_{min},
+      max_{max},
+      timer_{registry->GetTimer(id_)} {}
+
+static nanos restrict(nanos amount, nanos min, nanos max) {
+  auto r = amount;
+  if (r > max) {
+    r = max;
+  } else if (r < min) {
+    r = min;
+  }
+  return r;
+}
+
+void PercentileTimer::Record(std::chrono::nanoseconds amount) noexcept {
+  timer_->Record(amount);
+  auto restricted = restrict(amount, min_, max_);
+  auto index = PercentileBucketIndexOf(restricted.count());
+  auto& c = counters_.at(index);
+  if (!c) {
+    auto counterId = id_->WithStat("percentile")
+                         ->WithTag("percentile", kTimerTags.at(index));
+    counters_.at(index) = registry_->GetCounter(std::move(counterId));
+    c = counters_.at(index);
+  }
+  c->Increment();
+}
+
+double PercentileTimer::Percentile(double p) const noexcept {
+  std::array<int64_t, PercentileBucketsLength()> counts{};
+  for (size_t i = 0; i < PercentileBucketsLength(); ++i) {
+    auto& c = counters_.at(i);
+    if (c) {
+      counts.at(i) = c->Count();
+    }
+  }
+  auto v = spectator::Percentile(counts, p);
+  return v / 1e9;
+}
+
+}  // namespace spectator

--- a/spectator/percentile_timer.h
+++ b/spectator/percentile_timer.h
@@ -1,0 +1,30 @@
+
+#pragma once
+
+#include <chrono>
+#include "id.h"
+#include "registry.h"
+#include "percentile_buckets.h"
+namespace spectator {
+
+class PercentileTimer {
+ public:
+  PercentileTimer(Registry* registry, IdPtr id, std::chrono::nanoseconds min,
+                  std::chrono::nanoseconds max) noexcept;
+
+  void Record(std::chrono::nanoseconds amount) noexcept;
+  int64_t Count() const noexcept { return timer_->Count(); }
+  int64_t TotalTime() const noexcept { return timer_->TotalTime(); }
+  double Percentile(double p) const noexcept;
+
+ private:
+  Registry* registry_;
+  IdPtr id_;
+  std::chrono::nanoseconds min_;
+  std::chrono::nanoseconds max_;
+  std::shared_ptr<Timer> timer_;
+  mutable std::array<std::shared_ptr<Counter>, PercentileBucketsLength()>
+      counters_{};
+};
+
+}  // namespace spectator

--- a/test/perc_buckets_test.cc
+++ b/test/perc_buckets_test.cc
@@ -1,0 +1,89 @@
+#include "../spectator/percentile_buckets.h"
+#include <gtest/gtest.h>
+#include <random>
+
+using namespace spectator;
+
+TEST(PercentileBuckets, IndexOf) {
+  EXPECT_EQ(0, PercentileBucketIndexOf(-1));
+  EXPECT_EQ(0, PercentileBucketIndexOf(0));
+  EXPECT_EQ(1, PercentileBucketIndexOf(1));
+  EXPECT_EQ(2, PercentileBucketIndexOf(2));
+  EXPECT_EQ(3, PercentileBucketIndexOf(3));
+  EXPECT_EQ(4, PercentileBucketIndexOf(4));
+  EXPECT_EQ(25, PercentileBucketIndexOf(87));
+  EXPECT_EQ(PercentileBucketsLength() - 1,
+            PercentileBucketIndexOf(std::numeric_limits<int64_t>::max()));
+}
+
+TEST(PercentileBuckets, IndexOfSanityCheck) {
+  std::mt19937_64 rng;
+  rng.seed(std::random_device()());
+
+  for (auto i = 0; i < 10000; ++i) {
+    auto v = static_cast<int64_t>(rng());
+    if (v < 0) {
+      EXPECT_EQ(0, PercentileBucketIndexOf(v));
+    } else {
+      auto b = PercentileBucket(v);
+      EXPECT_TRUE(v <= b) << v << " > " << b;
+    }
+  }
+}
+
+TEST(PercentileBuckets, BucketSanityCheck) {
+  std::mt19937_64 rng;
+  rng.seed(std::random_device()());
+
+  for (auto i = 0; i < 10000; ++i) {
+    auto v = static_cast<int64_t>(rng());
+    if (v < 0) {
+      EXPECT_EQ(1, PercentileBucket(v));
+    } else {
+      auto b = PercentileBucket(v);
+      EXPECT_TRUE(v <= b) << v << " > " << b;
+    }
+  }
+}
+
+TEST(PercentileBuckets, Percentiles) {
+  std::array<int64_t, PercentileBucketsLength()> counts{};
+
+  for (int i = 0; i < 100000; ++i) {
+    ++counts[PercentileBucketIndexOf(i)];
+  }
+
+  std::vector<double> pcts{0.0,  25.0, 50.0, 75.0, 90.0,
+                           95.0, 98.0, 99.0, 99.5, 100.0};
+  std::vector<double> results;
+  Percentiles(counts, pcts, &results);
+  ASSERT_EQ(results.size(), pcts.size());
+
+  std::vector<double> expected = {0.0,  25e3, 50e3, 75e3,   90e3,
+                                  95e3, 98e3, 99e3, 99.5e3, 100e3};
+
+  for (size_t i = 0; i < results.size(); ++i) {
+    auto threshold = 0.1 * expected.at(i);
+    EXPECT_NEAR(expected.at(i), results.at(i), threshold);
+  }
+}
+
+TEST(PercentileBuckets, Percentile) {
+  std::array<int64_t, PercentileBucketsLength()> counts{};
+
+  for (int i = 0; i < 100000; ++i) {
+    ++counts[PercentileBucketIndexOf(i)];
+  }
+
+  std::vector<double> pcts{0.0,  25.0, 50.0, 75.0, 90.0,
+                           95.0, 98.0, 99.0, 99.5, 100.0};
+  std::vector<double> results;
+  Percentiles(counts, pcts, &results);
+  ASSERT_EQ(results.size(), pcts.size());
+
+  for (double pct : pcts) {
+    auto expected = pct * 1e3;
+    auto threshold = 0.1 * expected;
+    EXPECT_NEAR(expected, Percentile(counts, pct), threshold);
+  }
+}

--- a/test/perc_dist_summary_test.cc
+++ b/test/perc_dist_summary_test.cc
@@ -1,0 +1,65 @@
+#include <fmt/ostream.h>
+#include "../spectator/percentile_distribution_summary.h"
+#include <gtest/gtest.h>
+#include "../spectator/memory.h"
+#include "percentile_bucket_tags.inc"
+#include "test_utils.h"
+
+using namespace spectator;
+
+std::unique_ptr<PercentileDistributionSummary> getDS(Registry* r) {
+  auto id = r->CreateId("ds", Tags{});
+  return std::make_unique<PercentileDistributionSummary>(r, id);
+}
+
+TEST(PercentileDistributionSummary, Percentile) {
+  Registry r{GetConfiguration(), DefaultLogger()};
+  auto t = getDS(&r);
+
+  for (auto i = 0; i < 100000; ++i) {
+    t->Record(i);
+  }
+
+  for (auto i = 0; i <= 100; ++i) {
+    auto expected = 1e3 * i;
+    auto threshold = 0.15 * expected;
+    EXPECT_NEAR(expected, t->Percentile(i), threshold);
+  }
+}
+
+TEST(PercentileDistributionSummary, Measure) {
+  Registry r{GetConfiguration(), DefaultLogger()};
+  auto t = getDS(&r);
+
+  t->Record(42);
+
+  auto ms = r.Measurements();
+  auto actual = measurements_to_map(ms);
+  auto expected = std::map<std::string, double>{};
+
+  auto percentileTag = kDistTags.at(PercentileBucketIndexOf(42));
+  expected[fmt::format("ds|percentile={}|statistic=percentile",
+                       percentileTag)] = 1;
+
+  expected["ds|statistic=count"] = 1;
+  expected["ds|statistic=max"] = 42;
+  expected["ds|statistic=totalAmount"] = 42;
+  expected["ds|statistic=totalOfSquares"] = 42 * 42;
+
+  ASSERT_EQ(expected.size(), actual.size());
+  for (const auto& expected_m : expected) {
+    EXPECT_DOUBLE_EQ(expected_m.second, actual[expected_m.first]);
+  }
+}
+
+TEST(PercentileDistributionSummary, CountTotal) {
+  Registry r{GetConfiguration(), DefaultLogger()};
+  auto t = getDS(&r);
+
+  for (auto i = 0; i < 100; ++i) {
+    t->Record(i);
+  }
+
+  EXPECT_EQ(t->Count(), 100);
+  EXPECT_EQ(t->TotalAmount(), 100 * 99 / 2);  // sum(1,n) = n * (n - 1) / 2
+}

--- a/test/perc_timer_test.cc
+++ b/test/perc_timer_test.cc
@@ -1,0 +1,119 @@
+#include <fmt/ostream.h>
+#include "../spectator/percentile_timer.h"
+#include <gtest/gtest.h>
+#include "../spectator/memory.h"
+#include "percentile_bucket_tags.inc"
+#include "test_utils.h"
+
+using namespace spectator;
+
+using secs = std::chrono::seconds;
+using nanos = std::chrono::nanoseconds;
+using millis = std::chrono::milliseconds;
+
+std::unique_ptr<PercentileTimer> getTimer(Registry* r) {
+  auto id = r->CreateId("t", Tags{});
+  return std::make_unique<PercentileTimer>(r, id, nanos{0}, secs{100});
+}
+
+TEST(PercentileTimer, Percentile) {
+  Registry r{GetConfiguration(), DefaultLogger()};
+  auto t = getTimer(&r);
+
+  for (auto i = 0; i < 100000; ++i) {
+    t->Record(millis{i});
+  }
+
+  for (auto i = 0; i <= 100; ++i) {
+    auto expected = static_cast<double>(i);
+    auto threshold = 0.15 * expected;
+    EXPECT_NEAR(expected, t->Percentile(i), threshold);
+  }
+}
+
+TEST(PercentileTimer, Measure) {
+  Registry r{GetConfiguration(), DefaultLogger()};
+  auto t = getTimer(&r);
+
+  auto elapsed = millis{42};
+  t->Record(elapsed);
+
+  auto elapsed_nanos = std::chrono::duration_cast<nanos>(elapsed);
+
+  auto ms = r.Measurements();
+  auto actual = measurements_to_map(ms);
+  auto expected = std::map<std::string, double>{};
+
+  auto percentileTag =
+      kTimerTags.at(PercentileBucketIndexOf(elapsed_nanos.count()));
+  expected[fmt::format("t|percentile={}|statistic=percentile", percentileTag)] =
+      1;
+
+  expected["t|statistic=count"] = 1;
+  auto elapsed_secs = elapsed_nanos.count() / 1e9;
+  expected["t|statistic=max"] = elapsed_secs;
+  expected["t|statistic=totalTime"] = elapsed_secs;
+  expected["t|statistic=totalOfSquares"] = elapsed_secs * elapsed_secs;
+
+  ASSERT_EQ(expected.size(), actual.size());
+  for (const auto& expected_m : expected) {
+    EXPECT_DOUBLE_EQ(expected_m.second, actual[expected_m.first])
+        << expected_m.first;
+  }
+}
+
+TEST(PercentileTimer, CountTotal) {
+  Registry r{GetConfiguration(), DefaultLogger()};
+  auto t = getTimer(&r);
+
+  for (auto i = 0; i < 100; ++i) {
+    t->Record(nanos(i));
+  }
+
+  EXPECT_EQ(t->Count(), 100);
+  EXPECT_EQ(t->TotalTime(), 100 * 99 / 2);  // sum(1,n) = n * (n - 1) / 2
+}
+
+TEST(PercentileTimer, Restrict) {
+  Registry r{GetConfiguration(), DefaultLogger()};
+  auto id = r.CreateId("t", Tags{});
+  PercentileTimer t{&r, id, millis(5), secs{2}};
+
+  t.Record(millis(1));
+  t.Record(secs(10));
+  t.Record(millis(10));
+
+  // not restricted here
+  nanos total = millis(1) + secs(10) + millis(10);
+  EXPECT_EQ(t.TotalTime(), total.count());
+  EXPECT_EQ(t.Count(), 3);
+
+  auto measurements = r.Measurements();
+  auto actual = measurements_to_map(measurements);
+  auto expected = std::map<std::string, double>{};
+
+  // 5ms
+  auto minPercTag = kTimerTags.at(PercentileBucketIndexOf(5l * 1000 * 1000));
+  // 2s
+  auto maxPercTag =
+      kTimerTags.at(PercentileBucketIndexOf(2l * 1000 * 1000 * 1000));
+  // 10ms --> not restricted
+  auto percTag = kTimerTags.at(PercentileBucketIndexOf(10l * 1000 * 1000));
+
+  expected[fmt::format("t|percentile={}|statistic=percentile", minPercTag)] = 1;
+  expected[fmt::format("t|percentile={}|statistic=percentile", maxPercTag)] = 1;
+  expected[fmt::format("t|percentile={}|statistic=percentile", percTag)] = 1;
+
+  expected["t|statistic=count"] = 3;
+  auto elapsed_secs = total.count() / 1e9;
+  auto totalSq = (1e6 * 1e6 + 10e9 * 10e9 + 10e6 * 10e6) / 1e18;
+  expected["t|statistic=max"] = 10;
+  expected["t|statistic=totalTime"] = elapsed_secs;
+  expected["t|statistic=totalOfSquares"] = totalSq;
+
+  ASSERT_EQ(expected.size(), actual.size());
+  for (const auto& expected_m : expected) {
+    EXPECT_DOUBLE_EQ(expected_m.second, actual[expected_m.first])
+        << expected_m.first;
+  }
+}

--- a/test/test_utils.cc
+++ b/test/test_utils.cc
@@ -1,0 +1,22 @@
+#include <fmt/format.h>
+#include "test_utils.h"
+
+std::string id_to_string(const spectator::Id& id) {
+  std::string res = id.Name();
+  const auto& tags = id.GetTags();
+  std::map<std::string, std::string> sorted_tags{tags.begin(), tags.end()};
+
+  for (const auto& pair : sorted_tags) {
+    res += fmt::format("|{}={}", pair.first, pair.second);
+  }
+  return res;
+}
+
+std::map<std::string, double> measurements_to_map(
+    const std::vector<spectator::Measurement>& measurements) {
+  auto res = std::map<std::string, double>();
+  for (const auto& m : measurements) {
+    res[id_to_string(*m.id)] = m.value;
+  }
+  return res;
+}

--- a/test/test_utils.h
+++ b/test/test_utils.h
@@ -1,0 +1,9 @@
+#pragma once
+
+#include "../spectator/measurement.h"
+#include <map>
+#include <string>
+#include <vector>
+
+std::map<std::string, double> measurements_to_map(
+    const std::vector<spectator::Measurement>& measurements);


### PR DESCRIPTION
In preparation for supporting [common ipc metrics](https://netflix.github.io/spectator/en/latest/ext/ipc/) for our
http client, add support for percentile timers and distribution
summaries