### PR TITLE
Restrict values for Percentile Dist Summaries

### DIFF
--- a/spectator/percentile_distribution_summary.h
+++ b/spectator/percentile_distribution_summary.h
@@ -8,7 +8,8 @@ namespace spectator {
 
 class PercentileDistributionSummary {
  public:
-  PercentileDistributionSummary(Registry* registry, IdPtr id) noexcept;
+  PercentileDistributionSummary(Registry* registry, IdPtr id, int64_t min,
+                                int64_t max) noexcept;
 
   void Record(int64_t amount) noexcept;
   int64_t Count() const noexcept { return dist_summary_->Count(); }
@@ -18,6 +19,8 @@ class PercentileDistributionSummary {
  private:
   Registry* registry_;
   IdPtr id_;
+  int64_t min_;
+  int64_t max_;
   std::shared_ptr<DistributionSummary> dist_summary_;
   mutable std::array<std::shared_ptr<Counter>, PercentileBucketsLength()>
       counters_{};

--- a/spectator/percentile_timer.cc
+++ b/spectator/percentile_timer.cc
@@ -1,5 +1,6 @@
 #include "percentile_timer.h"
 #include "percentile_bucket_tags.inc"
+#include "util.h"
 
 using nanos = std::chrono::nanoseconds;
 
@@ -14,16 +15,6 @@ PercentileTimer::PercentileTimer(spectator::Registry* registry,
       min_{min},
       max_{max},
       timer_{registry->GetTimer(id_)} {}
-
-static nanos restrict(nanos amount, nanos min, nanos max) {
-  auto r = amount;
-  if (r > max) {
-    r = max;
-  } else if (r < min) {
-    r = min;
-  }
-  return r;
-}
 
 void PercentileTimer::Record(std::chrono::nanoseconds amount) noexcept {
   timer_->Record(amount);

--- a/spectator/util.h
+++ b/spectator/util.h
@@ -1,0 +1,16 @@
+#pragma once
+
+namespace spectator {
+
+template <typename T>
+T restrict(T amount, T min, T max) {
+  auto r = amount;
+  if (r > max) {
+    r = max;
+  } else if (r < min) {
+    r = min;
+  }
+  return r;
+}
+
+}  // namespace spectator


### PR DESCRIPTION
Use the same API that we have for percentile timers where the values
recorded are restricted to a min and max value specified by the user.