### PR TITLE
Use common-ipc metric names for our http-client

### DIFF
--- a/spectator/config.h
+++ b/spectator/config.h
@@ -13,8 +13,8 @@ class Config {
   Config() = default;
   Config(const Config&) = default;
 
-  Config(std::map<std::string, std::string> c_tags, int read_to_ms, int connect_to_ms,
-         int batch_sz, int freq, std::string publish_uri)
+  Config(std::map<std::string, std::string> c_tags, int read_to_ms,
+         int connect_to_ms, int batch_sz, int freq, std::string publish_uri)
       : common_tags{std::move(c_tags)},
         read_timeout{std::chrono::milliseconds{read_to_ms}},
         connect_timeout{std::chrono::milliseconds{connect_to_ms}},

--- a/spectator/id.cc
+++ b/spectator/id.cc
@@ -1,6 +1,5 @@
 #include "id.h"
 #include "memory.h"
-#include <ostream>
 #include <utility>
 
 namespace spectator {
@@ -19,21 +18,6 @@ std::unique_ptr<spectator::Id> Id::WithTag(const std::string& key,
   Tags tags{GetTags()};
   tags.add(key, value);
   return std::make_unique<Id>(Name(), tags);
-}
-
-inline std::ostream& operator<<(std::ostream& os, const Tags& tags) {
-  bool first = true;
-  os << '[';
-  for (const auto& tag : tags) {
-    if (first) {
-      first = false;
-    } else {
-      os << ", ";
-    }
-    os << tag.first << "->" << tag.second;
-  }
-  os << ']';
-  return os;
 }
 
 std::ostream& operator<<(std::ostream& os, const Id& id) {

--- a/spectator/id.h
+++ b/spectator/id.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <memory>
+#include <ostream>
 #include <string>
 #include <ska/flat_hash_map.hpp>
 
@@ -55,6 +56,21 @@ class Tags {
 
   table_t::const_iterator end() const { return entries_.end(); }
 };
+
+inline std::ostream& operator<<(std::ostream& os, const Tags& tags) {
+  bool first = true;
+  os << '[';
+  for (const auto& tag : tags) {
+    if (first) {
+      first = false;
+    } else {
+      os << ", ";
+    }
+    os << tag.first << "->" << tag.second;
+  }
+  os << ']';
+  return os;
+}
 
 class Id {
  public:

--- a/test/http_server.h
+++ b/test/http_server.h
@@ -26,9 +26,7 @@ class http_server {
     accept_sleep_ = millis;
   }
 
-  void set_sleep_number(int nr) {
-    sleep_number_ = nr;
-  }
+  void set_sleep_number(int nr) { sleep_number_ = nr; }
 
   void start() noexcept;
 

--- a/test/publisher_test.cc
+++ b/test/publisher_test.cc
@@ -11,11 +11,9 @@ using spectator::Publisher;
 using spectator::Registry;
 
 namespace {
-class TestClock {};
 
 class TestRegistry : public Registry {
  public:
-  using clock = TestClock;
   TestRegistry(std::unique_ptr<Config> config)
       : Registry(std::move(config), DefaultLogger()) {}
 };


### PR DESCRIPTION
Use the common-ipc names (including using a percentile timer for
ipc.client.call) for our http client