### PR TITLE
Update Bazel build

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -1,14 +1,45 @@
 cc_library(
     name = "spectator",
     srcs = glob(["spectator/*.cc"]),
-    hdrs = glob(["spectator/*.h"]),
+    hdrs = glob(["spectator/*.h"]) + [
+        "percentile_bucket_tags.inc",
+        "percentile_bucket_values.inc",
+    ],
     visibility = ["//visibility:public"],
     deps = [
+        "@com_github_fmtlib_fmt//:fmtlib",
+        "@com_github_gabime_spdlog//:spdlog",
+        "@com_github_skarupke_flat_hash_map//:flat_hash_map",
+        "@com_github_tencent_rapidjson//:rapidjson",
         "@curl",
-        "@spectator_flat_hash_map//:flat_hash_map",
-        "@spectator_fmtlib//:fmtlib",
-        "@spectator_pcre//:pcre",
-        "@spectator_rapidjson//:rapidjson",
-        "@spectator_spdlog//:spdlog",
+        "@org_exim_pcre//:pcre",
+    ],
+)
+
+cc_binary(
+    name = "gen_perc_bucket_tags",
+    srcs = ["gen_perc_bucket_tags.cc"],
+)
+
+cc_binary(
+    name = "gen_perc_bucket_values",
+    srcs = ["gen_perc_bucket_values.cc"],
+)
+
+genrule(
+    name = "gen_perc_bucket_tags_rule",
+    outs = ["percentile_bucket_tags.inc"],
+    cmd = "$(location gen_perc_bucket_tags) > $@",
+    tools = [
+        "gen_perc_bucket_tags",
+    ],
+)
+
+genrule(
+    name = "gen_perc_bucket_values_rule",
+    outs = ["percentile_bucket_values.inc"],
+    cmd = "$(location gen_perc_bucket_values) > $@",
+    tools = [
+        "gen_perc_bucket_values",
     ],
 )

--- a/dependencies.bzl
+++ b/dependencies.bzl
@@ -10,15 +10,51 @@
 # https://github.com/google/nomulus/blob/master/java/google/registry/repositories.bzl and the corresponding
 # https://github.com/google/nomulus/blob/master/WORKSPACE. Discussion https://github.com/bazelbuild/bazel/issues/1952.
 
-# We feel like this is too fragile, complex and verbose and just sandbox all dependencies by prefixing them thus hiding
-# from the consumers and avoiding any possible name conflicts.
-# This will possibly change once Bazel comes up with a better standardized solution but should suffice for now.
-
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
-def spectator_dependencies():
+def spectator_dependencies(
+        omit_curl = False,
+        omit_boringssl = False,
+        omit_net_zlib_zlib = False,
+        omit_com_github_skarupke_flat_hash_map = False,
+        omit_com_github_fmtlib_fmt = False,
+        omit_org_exim_pcre = False,
+        omit_com_github_tencent_rapidjson = False,
+        omit_com_github_gabime_spdlog = False,
+        omit_com_google_googletest = False):
+    if not omit_curl:
+        _curl()
+
+    # curl dependency.
+    if not omit_boringssl:
+        _boringssl()
+
+    # curl dependency.
+    if not omit_net_zlib_zlib:
+        _net_zlib_zlib()
+
+    if not omit_com_github_skarupke_flat_hash_map:
+        _com_github_skarupke_flat_hash_map()
+
+    if not omit_com_github_fmtlib_fmt:
+        _com_github_fmtlib_fmt()
+
+    if not omit_org_exim_pcre:
+        _org_exim_pcre()
+
+    if not omit_com_github_tencent_rapidjson:
+        _com_github_tencent_rapidjson()
+
+    if not omit_com_github_gabime_spdlog:
+        _com_github_gabime_spdlog()
+
+    if not omit_com_google_googletest:
+        _com_google_googletest()
+
+def _curl():
+    # https://github.com/tensorflow/tensorflow/blob/master/tensorflow/workspace.bzl.
     http_archive(
-        # Does not build with a different name right now.
+        # Needs build file updates to build with reverse fqdn.
         name = "curl",
         build_file = "@spectator//third_party:curl.BUILD",
         sha256 = "e9c37986337743f37fd14fe8737f246e97aec94b39d1b71e8a5973f72a9fc4f5",
@@ -29,19 +65,21 @@ def spectator_dependencies():
         ],
     )
 
-    # curl dependency.
+def _boringssl():
+    # https://github.com/tensorflow/tensorflow/blob/master/tensorflow/workspace.bzl.
     http_archive(
-        name = "spectator_boringssl",
-        # Use commits from branch "chromium-stable-with-bazel"
-        sha256 = "a4a71d97b90825f509c472cc9ad2404d4100f6cce042fc159388956bc5c616fb",
-        strip_prefix = "boringssl-77e47de9e16ec8865d1bc6d614dd918141f094d2",
-        # chromium-71.0.3578.80
-        urls = ["https://github.com/google/boringssl/archive/77e47de9e16ec8865d1bc6d614dd918141f094d2.tar.gz"],
+        # OSS projects like Envoy use short name, update when switch to reverse fqdn.
+        name = "boringssl",
+        sha256 = "1188e29000013ed6517168600fc35a010d58c5d321846d6a6dfee74e4c788b45",
+        strip_prefix = "boringssl-7f634429a04abc48e2eb041c81c5235816c96514",
+        urls = ["https://github.com/google/boringssl/archive/7f634429a04abc48e2eb041c81c5235816c96514.tar.gz"],
     )
 
-    # curl dependency.
+def _net_zlib_zlib():
+    # https://github.com/tensorflow/tensorflow/blob/master/tensorflow/workspace.bzl.
     http_archive(
-        name = "spectator_zlib",
+        # Envoy defines archive source "net_zib" for external cmake target "zlib" so neither are usable.
+        name = "net_zlib_zlib",
         build_file = "@spectator//third_party:zlib.BUILD",
         sha256 = "c3e5e9fdd5004dcb542feda5ee4f0ff0744628baf8ed2dd5d66f8ca1197cb1a1",
         strip_prefix = "zlib-1.2.11",
@@ -51,24 +89,29 @@ def spectator_dependencies():
         ],
     )
 
+def _com_github_skarupke_flat_hash_map():
     http_archive(
-        name = "spectator_flat_hash_map",
+        name = "com_github_skarupke_flat_hash_map",
         build_file = "@spectator//third_party:flat_hash_map.BUILD",
         sha256 = "513efb9c2f246b6df9fa16c5640618f09804b009e69c8f7bd18b3099a11203d5",
         strip_prefix = "flat_hash_map-2c4687431f978f02a3780e24b8b701d22aa32d9c",
         urls = ["https://github.com/skarupke/flat_hash_map/archive/2c4687431f978f02a3780e24b8b701d22aa32d9c.zip"],
     )
 
+def _com_github_fmtlib_fmt():
+    # https://github.com/envoyproxy/envoy/blob/master/bazel/repository_locations.bzl.
     http_archive(
-        name = "spectator_fmtlib",
+        name = "com_github_fmtlib_fmt",
         build_file = "@spectator//third_party:fmtlib.BUILD",
-        sha256 = "43894ab8fe561fc9e523a8024efc23018431fa86b95d45b06dbe6ddb29ffb6cd",
-        strip_prefix = "fmt-5.2.1",
-        urls = ["https://github.com/fmtlib/fmt/releases/download/5.2.1/fmt-5.2.1.zip"],
+        sha256 = "4c0741e10183f75d7d6f730b8708a99b329b2f942dad5a9da3385ab92bb4a15c",
+        strip_prefix = "fmt-5.3.0",
+        urls = ["https://github.com/fmtlib/fmt/releases/download/5.3.0/fmt-5.3.0.zip"],
     )
 
+def _org_exim_pcre():
+    # https://github.com/tensorflow/tensorflow/blob/master/tensorflow/workspace.bzl.
     http_archive(
-        name = "spectator_pcre",
+        name = "org_exim_pcre",
         build_file = "@spectator//third_party:pcre.BUILD",
         sha256 = "69acbc2fbdefb955d42a4c606dfde800c2885711d2979e356c0636efde9ec3b5",
         strip_prefix = "pcre-8.42",
@@ -78,25 +121,31 @@ def spectator_dependencies():
         ],
     )
 
+def _com_github_tencent_rapidjson():
+    # https://github.com/envoyproxy/envoy/blob/master/bazel/repository_locations.bzl.
     http_archive(
-        name = "spectator_rapidjson",
+        name = "com_github_tencent_rapidjson",
         build_file = "@spectator//third_party:rapidjson.BUILD",
         sha256 = "bf7ced29704a1e696fbccf2a2b4ea068e7774fa37f6d7dd4039d0787f8bed98e",
         strip_prefix = "rapidjson-1.1.0",
         urls = ["https://github.com/Tencent/rapidjson/archive/v1.1.0.tar.gz"],
     )
 
+def _com_github_gabime_spdlog():
+    # https://github.com/envoyproxy/envoy/blob/master/bazel/repository_locations.bzl.
     http_archive(
-        name = "spectator_spdlog",
+        name = "com_github_gabime_spdlog",
         build_file = "@spectator//third_party:spdlog.BUILD",
-        sha256 = "867a4b7cedf9805e6f76d3ca41889679054f7e5a3b67722fe6d0eae41852a767",
-        strip_prefix = "spdlog-1.2.1",
-        urls = ["https://github.com/gabime/spdlog/archive/v1.2.1.tar.gz"],
+        sha256 = "160845266e94db1d4922ef755637f6901266731c4cb3b30b45bf41efa0e6ab70",
+        strip_prefix = "spdlog-1.3.1",
+        urls = ["https://github.com/gabime/spdlog/archive/v1.3.1.tar.gz"],
     )
 
+def _com_google_googletest():
+    # https://github.com/envoyproxy/envoy/blob/master/bazel/repository_locations.bzl.
     http_archive(
-        name = "spectator_googletest",
-        sha256 = "9bf1fe5182a604b4135edc1a425ae356c9ad15e9b23f9f12a02e80184c3a249c",
+        name = "com_google_googletest",
+        sha256 = "a4cb4b0c3ebb191b798594aca674ad47eee255dcb4c26885cf7f49777703484f",
         strip_prefix = "googletest-release-1.8.1",
         urls = ["https://github.com/google/googletest/archive/release-1.8.1.tar.gz"],
     )

--- a/third_party/curl.BUILD
+++ b/third_party/curl.BUILD
@@ -254,10 +254,10 @@ cc_library(
     }),
     visibility = ["//visibility:public"],
     deps = [
-        "@spectator_zlib//:zlib",
+        "@net_zlib_zlib//:zlib",
     ] + select({
         "//conditions:default": [
-            "@spectator_boringssl//:ssl",
+            "@boringssl//:ssl",
         ],
     }),
 )

--- a/third_party/fmtlib.BUILD
+++ b/third_party/fmtlib.BUILD
@@ -1,3 +1,5 @@
+# https://github.com/envoyproxy/envoy/blob/master/bazel/external/fmtlib.BUILD.
+
 cc_library(
     name = "fmtlib",
     srcs = glob([

--- a/third_party/rapidjson.BUILD
+++ b/third_party/rapidjson.BUILD
@@ -1,3 +1,5 @@
+# https://github.com/envoyproxy/envoy/blob/master/bazel/external/rapidjson.BUILD.
+
 cc_library(
     name = "rapidjson",
     hdrs = glob(["include/rapidjson/**/*.h"]),

--- a/third_party/spdlog.BUILD
+++ b/third_party/spdlog.BUILD
@@ -1,3 +1,5 @@
+# https://github.com/envoyproxy/envoy/blob/master/bazel/external/spdlog.BUILD.
+
 cc_library(
     name = "spdlog",
     hdrs = glob([
@@ -7,5 +9,5 @@ cc_library(
     defines = ["SPDLOG_FMT_EXTERNAL"],
     includes = ["include"],
     visibility = ["//visibility:public"],
-    deps = ["@spectator_fmtlib//:fmtlib"],
+    deps = ["@com_github_fmtlib_fmt//:fmtlib"],
 )

--- a/third_party/zlib.BUILD
+++ b/third_party/zlib.BUILD
@@ -1,3 +1,5 @@
+# https://github.com/tensorflow/tensorflow/blob/master/third_party/zlib.BUILD
+
 licenses(["notice"])  # BSD/MIT-like license (for zlib)
 
 cc_library(


### PR DESCRIPTION
Make transitive Bazel dependencies omit-able (so that projects depending on Spectator which already have some of them can skip Spectator's), add tags/values generation step via genrules, update boringssl, fmtlib, spdlog, googletest versions.