### PR TITLE
Use frequency in milliseconds for consistency

### DIFF
--- a/spectator/config.h
+++ b/spectator/config.h
@@ -14,18 +14,18 @@ class Config {
   Config(const Config&) = default;
 
   Config(std::map<std::string, std::string> c_tags, int read_to_ms,
-         int connect_to_ms, int batch_sz, int freq, std::string publish_uri)
+         int connect_to_ms, int batch_sz, int freq_ms, std::string publish_uri)
       : common_tags{std::move(c_tags)},
         read_timeout{std::chrono::milliseconds{read_to_ms}},
         connect_timeout{std::chrono::milliseconds{connect_to_ms}},
         batch_size{batch_sz},
-        frequency{freq},
+        frequency{std::chrono::milliseconds{freq_ms}},
         uri{std::move(publish_uri)} {}
   std::map<std::string, std::string> common_tags;
   std::chrono::milliseconds read_timeout;
   std::chrono::milliseconds connect_timeout;
   int batch_size;
-  int frequency;  // in seconds
+  std::chrono::milliseconds frequency;
   std::string uri;
 
   // sub-classes can override this method implementing custom logic


### PR DESCRIPTION
Timeouts are expressed in milliseconds, so for consistency also use
milliseconds for the frequency at which payloads are sent to the
aggregators