### PR TITLE
Fix bug in shutdown

### DIFF
--- a/spectator/publisher.h
+++ b/spectator/publisher.h
@@ -36,13 +36,12 @@ class Publisher {
 
   void Stop() {
     if (started_.exchange(false)) {
-      registry_->GetLogger()->warn(
-          "Registry was never started. Ignoring stop request");
-
-    } else {
       should_stop_ = true;
       cv_.notify_all();
       sender_thread_.join();
+    } else {
+      registry_->GetLogger()->warn(
+          "Registry was never started. Ignoring stop request");
     }
 
     if (http_initialized_.exchange(false)) {


### PR DESCRIPTION
We were not properly checking the status of the started flag, and this
prevented the shutdown sequence from occuring. This also had the side
effect of causing a SIGABRT when running an app that was using this
library but couldn't start it due to env vars missing.