### PR TITLE
Fix JSON stringification in http client

### DIFF
--- a/spectator/http_client.cc
+++ b/spectator/http_client.cc
@@ -234,7 +234,7 @@ std::string HttpClient::payload_to_str(
       rapidjson::GenericStringBuffer<rapidjson::UTF8<>,
                                      rapidjson::MemoryPoolAllocator<>>;
   MyBuffer buffer{&allocator};
-  rapidjson::Writer<MyBuffer> writer;
+  rapidjson::Writer<MyBuffer> writer{buffer};
   payload.Accept(writer);
   std::string res{buffer.GetString()};
   return res;

--- a/spectator/http_client.cc
+++ b/spectator/http_client.cc
@@ -107,6 +107,10 @@ class CurlHandle {
 
 }  // namespace
 
+HttpClient::HttpClient(Registry* registry, HttpClientConfig config)
+    : registry_(registry),
+      config_{config} {}
+
 int HttpClient::do_post(const std::string& url,
                         std::shared_ptr<CurlHeaders> headers,
                         const char* payload, size_t size,
@@ -228,13 +232,8 @@ void HttpClient::GlobalShutdown() noexcept {
 
 std::string HttpClient::payload_to_str(
     const rapidjson::Document& payload) const {
-  rapidjson::MemoryPoolAllocator<> allocator{json_buffer_.get(),
-                                             config_.json_buffer_size};
-  using MyBuffer =
-      rapidjson::GenericStringBuffer<rapidjson::UTF8<>,
-                                     rapidjson::MemoryPoolAllocator<>>;
-  MyBuffer buffer{&allocator};
-  rapidjson::Writer<MyBuffer> writer{buffer};
+  rapidjson::StringBuffer buffer;
+  rapidjson::Writer<rapidjson::StringBuffer> writer{buffer};
   payload.Accept(writer);
   std::string res{buffer.GetString()};
   return res;

--- a/spectator/http_client.h
+++ b/spectator/http_client.h
@@ -16,7 +16,6 @@ struct HttpClientConfig {
   std::chrono::milliseconds connect_timeout;
   std::chrono::milliseconds read_timeout;
   bool compress;
-  size_t json_buffer_size;
 };
 
 class HttpClient {
@@ -24,11 +23,7 @@ class HttpClient {
   static constexpr const char* const kJsonType =
       "Content-Type: application/json";
 
-  HttpClient(Registry* registry, HttpClientConfig config)
-      : registry_(registry),
-        config_{config},
-        json_buffer_{
-            std::unique_ptr<char[]>(new char[config.json_buffer_size])} {}
+  HttpClient(Registry* registry, HttpClientConfig config);
 
   int Post(const std::string& url, const char* content_type,
            const char* payload, size_t size) const;
@@ -46,7 +41,6 @@ class HttpClient {
  private:
   Registry* registry_;
   HttpClientConfig config_;
-  std::unique_ptr<char[]> json_buffer_;
 
   int do_post(const std::string& url, std::shared_ptr<CurlHeaders> headers,
               const char* payload, size_t size, int attempt_number) const;

--- a/spectator/publisher.h
+++ b/spectator/publisher.h
@@ -220,7 +220,7 @@ class Publisher {
     if (connect_timeout.count() == 0) {
       connect_timeout = std::chrono::seconds(2);
     }
-    return HttpClientConfig{connect_timeout, read_timeout, true, 32u * 1024u};
+    return HttpClientConfig{connect_timeout, read_timeout, true};
   }
 
   std::pair<size_t, size_t> send_metrics() {


### PR DESCRIPTION
Did not have a test case for the overload to `Post` with a JSON
document. The way the json-to-str was being done would cause a segment
violation since the writer did not have a buffer associated with it.