### PR TITLE
Option for reading the response body for http reqs

### DIFF
--- a/spectator/publisher.h
+++ b/spectator/publisher.h
@@ -220,7 +220,7 @@ class Publisher {
     if (connect_timeout.count() == 0) {
       connect_timeout = std::chrono::seconds(2);
     }
-    return HttpClientConfig{connect_timeout, read_timeout, true};
+    return HttpClientConfig{connect_timeout, read_timeout, true, false, false};
   }
 
   std::pair<size_t, size_t> send_metrics() {
@@ -244,7 +244,8 @@ class Publisher {
       auto to_advance = std::min(batch_size, to_end);
       auto to = from;
       std::advance(to, to_advance);
-      auto http_code = client.Post(cfg.uri, measurements_to_json(from, to));
+      auto http_code =
+          client.Post(cfg.uri, measurements_to_json(from, to)).status;
       if (http_code != 200) {
         registry_->GetLogger()->error(
             "Unable to send batch of {} measurements to publish: {}",

--- a/test/http_server.cc
+++ b/test/http_server.cc
@@ -13,7 +13,13 @@ using spectator::gzip_compress;
 
 http_server::http_server() noexcept {
   path_response_["/foo"] =
-      "HTTP/1.0 200 OK\nContent-Encoding: gzip\nContent-Length: 0\n";
+      "HTTP/1.0 200 OK\nContent-Length: 3\nX-Test: foo\n\nOK\n";
+  auto hdr_body = std::string("header body: ok\n");
+  auto hdr_response = fmt::format(
+      "HTTP/1.0 200 OK\nContent-Length: {}\nX-Test: some "
+      "server\nX-NoContent:\n\n{}",
+      hdr_body.length(), hdr_body);
+  path_response_["/hdr"] = hdr_response;
 }
 
 http_server::~http_server() {
@@ -156,7 +162,8 @@ void http_server::accept_request(int client) {
   while (n > 0) {
     auto bytes_read = read(client, p, (size_t)n);
     if (bytes_read == 0) {
-      logger->info("EOF while reading request body. {} bytes read, {} missing", content_len - n, n);
+      logger->info("EOF while reading request body. {} bytes read, {} missing",
+                   content_len - n, n);
       break;
     } else if (bytes_read < 0) {
       logger->error("Error reading client request: {}", strerror(errno));


### PR DESCRIPTION
Some uses of the http client require the body of the response from the
server for diagnostic purposes. This changes the signature of the `Post`
methods of the HTTP client to return an `HttpResponse` type instead of
the simple status code. The response includes the raw body as a string
(i.e. no decoding based on the encoding header from the server) and
a map of headers. Both are optional in case the client is not
interested.