### PR TITLE
Allow passing custom HTTP headers to GET requests

### DIFF
--- a/spectator/http_client.cc
+++ b/spectator/http_client.cc
@@ -6,7 +6,6 @@
 #include <utility>
 
 #include <curl/curl.h>
-#include <curl/multi.h>
 #include <rapidjson/stringbuffer.h>
 #include <rapidjson/writer.h>
 
@@ -157,6 +156,15 @@ HttpClient::HttpClient(Registry* registry, HttpClientConfig config)
 
 HttpResponse HttpClient::Get(const std::string& url) const {
   return perform("GET", url, std::make_shared<CurlHeaders>(), nullptr, 0u, 0);
+}
+
+HttpResponse HttpClient::Get(const std::string& url,
+                             const std::vector<std::string>& headers) const {
+  auto curl_headers = std::make_shared<CurlHeaders>();
+  for (const auto& h : headers) {
+    curl_headers->append(h);
+  }
+  return perform("GET", url, std::move(curl_headers), nullptr, 0u, 0);
 }
 
 inline bool is_retryable_error(int http_code) {

--- a/spectator/http_client.h
+++ b/spectator/http_client.h
@@ -4,6 +4,7 @@
 #include <map>
 #include <memory>
 #include <string>
+#include <vector>
 
 #include <rapidjson/document.h>
 #include <unordered_map>

--- a/spectator/http_client.h
+++ b/spectator/http_client.h
@@ -48,6 +48,8 @@ class HttpClient {
                     const rapidjson::Document& payload) const;
 
   HttpResponse Get(const std::string& url) const;
+  HttpResponse Get(const std::string& url,
+                   const std::vector<std::string>& headers) const;
 
   static void GlobalInit() noexcept;
   static void GlobalShutdown() noexcept;

--- a/test/http_server.cc
+++ b/test/http_server.cc
@@ -224,11 +224,6 @@ void http_server::accept_request(int client) {
   // TODO handle 404s
   const auto& response = path_response_[path];
 
-  // hack for /get503
-  if (strcmp(path, "/get503") == 0) {
-    path_response_["/get503"] = path_response_["/get"];
-  }
-
   // hack for /getheader - just echo the headers that start with X- back
   if (strcmp(path, "/getheader") != 0) {
     do_write(client, response);
@@ -242,6 +237,11 @@ void http_server::accept_request(int client) {
     }
     do_write(client, fmt::format("{}Content-length: {}\n\n{}", response,
                                  resp.length(), resp));
+  }
+
+  // hack for /get503
+  if (strcmp(path, "/get503") == 0) {
+    path_response_["/get503"] = path_response_["/get"];
   }
 }
 


### PR DESCRIPTION
Add an override to our internal HTTP client that supports custom HTTP
headers provided by the client of the library