### PR TITLE
Fix Clang/libc++ build

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -48,11 +48,13 @@ cc_library(
 cc_binary(
     name = "gen_perc_bucket_tags",
     srcs = ["gen_perc_bucket_tags.cc"],
+    linkopts = ["-pthread"],
 )
 
 cc_binary(
     name = "gen_perc_bucket_values",
     srcs = ["gen_perc_bucket_values.cc"],
+    linkopts = ["-pthread"],
 )
 
 genrule(

--- a/spectator/timer.cc
+++ b/spectator/timer.cc
@@ -30,7 +30,7 @@ std::vector<Measurement> Timer::Measure() const noexcept {
 }
 
 void Timer::Record(std::chrono::nanoseconds amount) noexcept {
-  auto ns = amount.count();
+  int64_t ns = amount.count();
   if (ns >= 0) {
     count_.fetch_add(1, std::memory_order_relaxed);
     total_.fetch_add(ns, std::memory_order_relaxed);


### PR DESCRIPTION
When linking with libc++, update_max template resolution fails due to ambiguity in chrono nanos type which is implementation-specific. Threads library also needs to be linked for generation utils.