### PR TITLE
Add support for bazel on OSX

### DIFF
--- a/dependencies.bzl
+++ b/dependencies.bzl
@@ -78,10 +78,10 @@ def _com_github_c_ares_c_ares():
     # https://github.com/grpc/grpc/blob/master/bazel/grpc_deps.bzl.
     http_archive(
         name = "com_github_c_ares_c_ares",
-        build_file = "@spectator//third_party:cares.BUILD",
-        sha256 = "e8c2751ddc70fed9dc6f999acd92e232d5846f009ee1674f8aee81f19b2b915a",
-        strip_prefix = "c-ares-e982924acee7f7313b4baa4ee5ec000c5e373c30",
-        url = "https://github.com/c-ares/c-ares/archive/e982924acee7f7313b4baa4ee5ec000c5e373c30.tar.gz",
+        build_file = "@spectator//third_party/cares:cares.BUILD",
+        strip_prefix = "c-ares-1.15.0",
+        sha256 = "6cdb97871f2930530c97deb7cf5c8fa4be5a0b02c7cea6e7c7667672a39d6852",
+        url = "https://github.com/c-ares/c-ares/releases/download/cares-1_15_0/c-ares-1.15.0.tar.gz",
     )
 
 def _boringssl():

--- a/third_party/BUILD
+++ b/third_party/BUILD
@@ -1,4 +1,0 @@
-exports_files([
-    "ares_build_genrule.h",
-    "ares_config_genrule.h",
-])

--- a/third_party/cares/ares_build.h
+++ b/third_party/cares/ares_build.h
@@ -1,7 +1,6 @@
-// https://github.com/grpc/grpc/blob/master/third_party/cares/ares_build.h.
-
 #ifndef __CARES_BUILD_H
 #define __CARES_BUILD_H
+
 
 /* Copyright (C) 2009 - 2013 by Daniel Stenberg et al
  *
@@ -85,8 +84,8 @@
 /* ================================================================ */
 
 #ifdef CARES_TYPEOF_ARES_SOCKLEN_T
-#error "CARES_TYPEOF_ARES_SOCKLEN_T shall not be defined except in ares_build.h"
-Error Compilation_aborted_CARES_TYPEOF_ARES_SOCKLEN_T_already_defined
+#  error "CARES_TYPEOF_ARES_SOCKLEN_T shall not be defined except in ares_build.h"
+   Error Compilation_aborted_CARES_TYPEOF_ARES_SOCKLEN_T_already_defined
 #endif
 
 /* ================================================================ */
@@ -94,118 +93,118 @@ Error Compilation_aborted_CARES_TYPEOF_ARES_SOCKLEN_T_already_defined
 /* ================================================================ */
 
 #if defined(__DJGPP__) || defined(__GO32__)
-#define CARES_TYPEOF_ARES_SOCKLEN_T int
+#  define CARES_TYPEOF_ARES_SOCKLEN_T int
 
 #elif defined(__SALFORDC__)
-#define CARES_TYPEOF_ARES_SOCKLEN_T int
+#  define CARES_TYPEOF_ARES_SOCKLEN_T int
 
 #elif defined(__BORLANDC__)
-#define CARES_TYPEOF_ARES_SOCKLEN_T int
+#  define CARES_TYPEOF_ARES_SOCKLEN_T int
 
 #elif defined(__TURBOC__)
-#define CARES_TYPEOF_ARES_SOCKLEN_T int
+#  define CARES_TYPEOF_ARES_SOCKLEN_T int
 
 #elif defined(__WATCOMC__)
-#define CARES_TYPEOF_ARES_SOCKLEN_T int
+#  define CARES_TYPEOF_ARES_SOCKLEN_T int
 
 #elif defined(__POCC__)
-#define CARES_TYPEOF_ARES_SOCKLEN_T int
+#  define CARES_TYPEOF_ARES_SOCKLEN_T int
 
 #elif defined(__LCC__)
-#define CARES_TYPEOF_ARES_SOCKLEN_T int
+#  define CARES_TYPEOF_ARES_SOCKLEN_T int
 
 #elif defined(__SYMBIAN32__)
-#define CARES_TYPEOF_ARES_SOCKLEN_T unsigned int
+#  define CARES_TYPEOF_ARES_SOCKLEN_T unsigned int
 
 #elif defined(__MWERKS__)
-#define CARES_TYPEOF_ARES_SOCKLEN_T int
+#  define CARES_TYPEOF_ARES_SOCKLEN_T int
 
 #elif defined(_WIN32_WCE)
-#define CARES_TYPEOF_ARES_SOCKLEN_T int
+#  define CARES_TYPEOF_ARES_SOCKLEN_T int
 
 #elif defined(__MINGW32__)
-#define CARES_TYPEOF_ARES_SOCKLEN_T int
+#  define CARES_TYPEOF_ARES_SOCKLEN_T int
 
 #elif defined(__VMS)
-#define CARES_TYPEOF_ARES_SOCKLEN_T unsigned int
+#  define CARES_TYPEOF_ARES_SOCKLEN_T unsigned int
 
 #elif defined(__OS400__)
-#if defined(__ILEC400__)
-#define CARES_TYPEOF_ARES_SOCKLEN_T socklen_t
-#define CARES_PULL_SYS_TYPES_H 1
-#define CARES_PULL_SYS_SOCKET_H 1
-#endif
+#  if defined(__ILEC400__)
+#    define CARES_TYPEOF_ARES_SOCKLEN_T socklen_t
+#    define CARES_PULL_SYS_TYPES_H      1
+#    define CARES_PULL_SYS_SOCKET_H     1
+#  endif
 
 #elif defined(__MVS__)
-#if defined(__IBMC__) || defined(__IBMCPP__)
-#define CARES_TYPEOF_ARES_SOCKLEN_T socklen_t
-#define CARES_PULL_SYS_TYPES_H 1
-#define CARES_PULL_SYS_SOCKET_H 1
-#endif
+#  if defined(__IBMC__) || defined(__IBMCPP__)
+#    define CARES_TYPEOF_ARES_SOCKLEN_T socklen_t
+#    define CARES_PULL_SYS_TYPES_H      1
+#    define CARES_PULL_SYS_SOCKET_H     1
+#  endif
 
 #elif defined(__370__)
-#if defined(__IBMC__) || defined(__IBMCPP__)
-#define CARES_TYPEOF_ARES_SOCKLEN_T socklen_t
-#define CARES_PULL_SYS_TYPES_H 1
-#define CARES_PULL_SYS_SOCKET_H 1
-#endif
+#  if defined(__IBMC__) || defined(__IBMCPP__)
+#    define CARES_TYPEOF_ARES_SOCKLEN_T socklen_t
+#    define CARES_PULL_SYS_TYPES_H      1
+#    define CARES_PULL_SYS_SOCKET_H     1
+#  endif
 
 #elif defined(TPF)
-#define CARES_TYPEOF_ARES_SOCKLEN_T int
+#  define CARES_TYPEOF_ARES_SOCKLEN_T int
 
 /* ===================================== */
 /*    KEEP MSVC THE PENULTIMATE ENTRY    */
 /* ===================================== */
 
 #elif defined(_MSC_VER)
-#define CARES_TYPEOF_ARES_SOCKLEN_T int
+#  define CARES_TYPEOF_ARES_SOCKLEN_T int
 
 /* ===================================== */
 /*    KEEP GENERIC GCC THE LAST ENTRY    */
 /* ===================================== */
 
 #elif defined(__GNUC__)
-#define CARES_TYPEOF_ARES_SOCKLEN_T socklen_t
-#define CARES_PULL_SYS_TYPES_H 1
-#define CARES_PULL_SYS_SOCKET_H 1
+#  define CARES_TYPEOF_ARES_SOCKLEN_T socklen_t
+#  define CARES_PULL_SYS_TYPES_H      1
+#  define CARES_PULL_SYS_SOCKET_H     1
 
 #else
-#error "Unknown non-configure build target!"
-Error Compilation_aborted_Unknown_non_configure_build_target
+#  error "Unknown non-configure build target!"
+   Error Compilation_aborted_Unknown_non_configure_build_target
 #endif
 
 /* CARES_PULL_SYS_TYPES_H is defined above when inclusion of header file  */
 /* sys/types.h is required here to properly make type definitions below.  */
 #ifdef CARES_PULL_SYS_TYPES_H
-#include <sys/types.h>
+#  include <sys/types.h>
 #endif
 
 /* CARES_PULL_SYS_SOCKET_H is defined above when inclusion of header file  */
 /* sys/socket.h is required here to properly make type definitions below.  */
 #ifdef CARES_PULL_SYS_SOCKET_H
-#include <sys/socket.h>
+#  include <sys/socket.h>
 #endif
 
 /* Data type definition of ares_socklen_t. */
 
 #ifdef CARES_TYPEOF_ARES_SOCKLEN_T
-    typedef CARES_TYPEOF_ARES_SOCKLEN_T ares_socklen_t;
+  typedef CARES_TYPEOF_ARES_SOCKLEN_T ares_socklen_t;
 #endif
 
 /* Data type definition of ares_ssize_t. */
 /* gRPC Manuel edit here!
  * Possibly include <_mingw.h> header to define __int64 type under mingw */
 #ifdef _WIN32
-#ifdef _WIN64
-#ifdef __MINGW32__
-#include <_mingw.h>
-#endif
-#define CARES_TYPEOF_ARES_SSIZE_T __int64
+#  ifdef _WIN64
+#    ifdef __MINGW32__
+#      include <_mingw.h>
+#    endif
+#    define CARES_TYPEOF_ARES_SSIZE_T __int64
+#  else
+#    define CARES_TYPEOF_ARES_SSIZE_T long
+#  endif
 #else
-#define CARES_TYPEOF_ARES_SSIZE_T long
-#endif
-#else
-#define CARES_TYPEOF_ARES_SSIZE_T ssize_t
+#  define CARES_TYPEOF_ARES_SSIZE_T ssize_t
 #endif
 
 typedef CARES_TYPEOF_ARES_SSIZE_T ares_ssize_t;
@@ -214,11 +213,11 @@ typedef CARES_TYPEOF_ARES_SSIZE_T ares_ssize_t;
  * Undefine UNICODE, as c-ares does not use the ANSI version of functions
  * explicitly. */
 #ifdef UNICODE
-#undef UNICODE
+#  undef UNICODE
 #endif
 
 #ifdef _UNICODE
-#undef _UNICODE
+#  undef _UNICODE
 #endif
 
 #endif /* __CARES_BUILD_H */

--- a/third_party/cares/config_darwin/ares_config.h
+++ b/third_party/cares/config_darwin/ares_config.h
@@ -1,0 +1,428 @@
+/* Generated from ares_config.h.cmake*/
+
+/* Define if building universal (internal helper macro) */
+#undef AC_APPLE_UNIVERSAL_BUILD
+
+/* define this if ares is built for a big endian system */
+#undef ARES_BIG_ENDIAN
+
+/* when building as static part of libcurl */
+#undef BUILDING_LIBCURL
+
+/* Defined for build that exposes internal static functions for testing. */
+#undef CARES_EXPOSE_STATICS
+
+/* Defined for build with symbol hiding. */
+#undef CARES_SYMBOL_HIDING
+
+/* Definition to make a library symbol externally visible. */
+#undef CARES_SYMBOL_SCOPE_EXTERN
+
+/* Use resolver library to configure cares */
+/* #undef CARES_USE_LIBRESOLV */
+
+/* if a /etc/inet dir is being used */
+#undef ETC_INET
+
+/* Define to the type of arg 2 for gethostname. */
+#define GETHOSTNAME_TYPE_ARG2 size_t
+
+/* Define to the type qualifier of arg 1 for getnameinfo. */
+#define GETNAMEINFO_QUAL_ARG1 
+
+/* Define to the type of arg 1 for getnameinfo. */
+#define GETNAMEINFO_TYPE_ARG1 struct sockaddr *
+
+/* Define to the type of arg 2 for getnameinfo. */
+#define GETNAMEINFO_TYPE_ARG2 socklen_t
+
+/* Define to the type of args 4 and 6 for getnameinfo. */
+#define GETNAMEINFO_TYPE_ARG46 socklen_t
+
+/* Define to the type of arg 7 for getnameinfo. */
+#define GETNAMEINFO_TYPE_ARG7 int
+
+/* Specifies the number of arguments to getservbyport_r */
+#define GETSERVBYPORT_R_ARGS 
+
+/* Define to 1 if you have AF_INET6. */
+#define HAVE_AF_INET6
+
+/* Define to 1 if you have the <arpa/inet.h> header file. */
+#define HAVE_ARPA_INET_H
+
+/* Define to 1 if you have the <arpa/nameser_compat.h> header file. */
+#define HAVE_ARPA_NAMESER_COMPAT_H
+
+/* Define to 1 if you have the <arpa/nameser.h> header file. */
+#define HAVE_ARPA_NAMESER_H
+
+/* Define to 1 if you have the <assert.h> header file. */
+#define HAVE_ASSERT_H
+
+/* Define to 1 if you have the `bitncmp' function. */
+/* #undef HAVE_BITNCMP */
+
+/* Define to 1 if bool is an available type. */
+#define HAVE_BOOL_T
+
+/* Define to 1 if you have the clock_gettime function and monotonic timer. */
+/* IMPORTANT: gRPC MANUAL EDIT HERE!
+ * defining HAVE_CLOCK_GETTIME_MONOTONIC breaks the MacOS build on gRPC CI */
+/* #undef HAVE_CLOCK_GETTIME_MONOTONIC */
+
+/* Define to 1 if you have the closesocket function. */
+/* #undef HAVE_CLOSESOCKET */
+
+/* Define to 1 if you have the CloseSocket camel case function. */
+/* #undef HAVE_CLOSESOCKET_CAMEL */
+
+/* Define to 1 if you have the connect function. */
+#define HAVE_CONNECT
+
+/* define if the compiler supports basic C++11 syntax */
+/* #undef HAVE_CXX11 */
+
+/* Define to 1 if you have the <dlfcn.h> header file. */
+#define HAVE_DLFCN_H
+
+/* Define to 1 if you have the <errno.h> header file. */
+#define HAVE_ERRNO_H
+
+/* Define to 1 if you have the fcntl function. */
+#define HAVE_FCNTL
+
+/* Define to 1 if you have the <fcntl.h> header file. */
+#define HAVE_FCNTL_H
+
+/* Define to 1 if you have a working fcntl O_NONBLOCK function. */
+#define HAVE_FCNTL_O_NONBLOCK
+
+/* Define to 1 if you have the freeaddrinfo function. */
+#define HAVE_FREEADDRINFO
+
+/* Define to 1 if you have a working getaddrinfo function. */
+#define HAVE_GETADDRINFO
+
+/* Define to 1 if the getaddrinfo function is threadsafe. */
+#define HAVE_GETADDRINFO_THREADSAFE
+
+/* Define to 1 if you have the getenv function. */
+#define HAVE_GETENV
+
+/* Define to 1 if you have the gethostbyaddr function. */
+#define HAVE_GETHOSTBYADDR
+
+/* Define to 1 if you have the gethostbyname function. */
+#define HAVE_GETHOSTBYNAME
+
+/* Define to 1 if you have the gethostname function. */
+#define HAVE_GETHOSTNAME
+
+/* Define to 1 if you have the getnameinfo function. */
+#define HAVE_GETNAMEINFO
+
+/* Define to 1 if you have the getservbyport_r function. */
+/* #undef HAVE_GETSERVBYPORT_R */
+
+/* Define to 1 if you have the `gettimeofday' function. */
+#define HAVE_GETTIMEOFDAY
+
+/* Define to 1 if you have the `if_indextoname' function. */
+#define HAVE_IF_INDEXTONAME
+
+/* Define to 1 if you have a IPv6 capable working inet_net_pton function. */
+#define HAVE_INET_NET_PTON
+
+/* Define to 1 if you have a IPv6 capable working inet_ntop function. */
+#define HAVE_INET_NTOP
+
+/* Define to 1 if you have a IPv6 capable working inet_pton function. */
+#define HAVE_INET_PTON
+
+/* Define to 1 if you have the <inttypes.h> header file. */
+#define HAVE_INTTYPES_H
+
+/* Define to 1 if you have the ioctl function. */
+#define HAVE_IOCTL
+
+/* Define to 1 if you have the ioctlsocket function. */
+/* #undef HAVE_IOCTLSOCKET */
+
+/* Define to 1 if you have the IoctlSocket camel case function. */
+/* #undef HAVE_IOCTLSOCKET_CAMEL */
+
+/* Define to 1 if you have a working IoctlSocket camel case FIONBIO function.
+   */
+/* #undef HAVE_IOCTLSOCKET_CAMEL_FIONBIO */
+
+/* Define to 1 if you have a working ioctlsocket FIONBIO function. */
+/* #undef HAVE_IOCTLSOCKET_FIONBIO */
+
+/* Define to 1 if you have a working ioctl FIONBIO function. */
+#define HAVE_IOCTL_FIONBIO
+
+/* Define to 1 if you have a working ioctl SIOCGIFADDR function. */
+#define HAVE_IOCTL_SIOCGIFADDR
+
+/* Define to 1 if you have the `resolve' library (-lresolve). */
+#define HAVE_LIBRESOLV
+
+/* Define to 1 if you have the <limits.h> header file. */
+#define HAVE_LIMITS_H
+
+/* if your compiler supports LL */
+#define HAVE_LL
+
+/* Define to 1 if the compiler supports the 'long long' data type. */
+#define HAVE_LONGLONG
+
+/* Define to 1 if you have the malloc.h header file. */
+/* #undef HAVE_MALLOC_H */
+
+/* Define to 1 if you have the memory.h header file. */
+#define HAVE_MEMORY_H
+
+/* Define to 1 if you have the MSG_NOSIGNAL flag. */
+/* #undef HAVE_MSG_NOSIGNAL */
+
+/* Define to 1 if you have the <netdb.h> header file. */
+#define HAVE_NETDB_H
+
+/* Define to 1 if you have the <netinet/in.h> header file. */
+#define HAVE_NETINET_IN_H
+
+/* Define to 1 if you have the <netinet/tcp.h> header file. */
+#define HAVE_NETINET_TCP_H
+
+/* Define to 1 if you have the <net/if.h> header file. */
+#define HAVE_NET_IF_H
+
+/* Define to 1 if you have PF_INET6. */
+#define HAVE_PF_INET6
+
+/* Define to 1 if you have the recv function. */
+#define HAVE_RECV
+
+/* Define to 1 if you have the recvfrom function. */
+#define HAVE_RECVFROM
+
+/* Define to 1 if you have the send function. */
+#define HAVE_SEND
+
+/* Define to 1 if you have the setsockopt function. */
+#define HAVE_SETSOCKOPT
+
+/* Define to 1 if you have a working setsockopt SO_NONBLOCK function. */
+/* #undef HAVE_SETSOCKOPT_SO_NONBLOCK */
+
+/* Define to 1 if you have the <signal.h> header file. */
+#define HAVE_SIGNAL_H
+
+/* Define to 1 if sig_atomic_t is an available typedef. */
+#define HAVE_SIG_ATOMIC_T
+
+/* Define to 1 if sig_atomic_t is already defined as volatile. */
+/* #undef HAVE_SIG_ATOMIC_T_VOLATILE */
+
+/* Define to 1 if your struct sockaddr_in6 has sin6_scope_id. */
+#define HAVE_SOCKADDR_IN6_SIN6_SCOPE_ID
+
+/* Define to 1 if you have the socket function. */
+#define HAVE_SOCKET
+
+/* Define to 1 if you have the <socket.h> header file. */
+/* #undef HAVE_SOCKET_H */
+
+/* Define to 1 if you have the <stdbool.h> header file. */
+#define HAVE_STDBOOL_H
+
+/* Define to 1 if you have the <stdint.h> header file. */
+#define HAVE_STDINT_H
+
+/* Define to 1 if you have the <stdlib.h> header file. */
+#define HAVE_STDLIB_H
+
+/* Define to 1 if you have the strcasecmp function. */
+#define HAVE_STRCASECMP
+
+/* Define to 1 if you have the strcmpi function. */
+/* #undef HAVE_STRCMPI */
+
+/* Define to 1 if you have the strdup function. */
+#define HAVE_STRDUP
+
+/* Define to 1 if you have the stricmp function. */
+/* #undef HAVE_STRICMP */
+
+/* Define to 1 if you have the <strings.h> header file. */
+#define HAVE_STRINGS_H
+
+/* Define to 1 if you have the <string.h> header file. */
+#define HAVE_STRING_H
+
+/* Define to 1 if you have the strncasecmp function. */
+#define HAVE_STRNCASECMP
+
+/* Define to 1 if you have the strncmpi function. */
+/* #undef HAVE_STRNCMPI */
+
+/* Define to 1 if you have the strnicmp function. */
+/* #undef HAVE_STRNICMP */
+
+/* Define to 1 if you have the <stropts.h> header file. */
+/* #undef HAVE_STROPTS_H */
+
+/* Define to 1 if you have struct addrinfo. */
+#define HAVE_STRUCT_ADDRINFO
+
+/* Define to 1 if you have struct in6_addr. */
+#define HAVE_STRUCT_IN6_ADDR
+
+/* Define to 1 if you have struct sockaddr_in6. */
+#define HAVE_STRUCT_SOCKADDR_IN6
+
+/* if struct sockaddr_storage is defined */
+#define HAVE_STRUCT_SOCKADDR_STORAGE
+
+/* Define to 1 if you have the timeval struct. */
+#define HAVE_STRUCT_TIMEVAL
+
+/* Define to 1 if you have the <sys/ioctl.h> header file. */
+#define HAVE_SYS_IOCTL_H
+
+/* Define to 1 if you have the <sys/param.h> header file. */
+#define HAVE_SYS_PARAM_H
+
+/* Define to 1 if you have the <sys/select.h> header file. */
+#define HAVE_SYS_SELECT_H
+
+/* Define to 1 if you have the <sys/socket.h> header file. */
+#define HAVE_SYS_SOCKET_H
+
+/* Define to 1 if you have the <sys/stat.h> header file. */
+#define HAVE_SYS_STAT_H
+
+/* Define to 1 if you have the <sys/time.h> header file. */
+#define HAVE_SYS_TIME_H
+
+/* Define to 1 if you have the <sys/types.h> header file. */
+#define HAVE_SYS_TYPES_H
+
+/* Define to 1 if you have the <sys/uio.h> header file. */
+#define HAVE_SYS_UIO_H
+
+/* Define to 1 if you have the <time.h> header file. */
+#define HAVE_TIME_H
+
+/* Define to 1 if you have the <unistd.h> header file. */
+#define HAVE_UNISTD_H
+
+/* Define to 1 if you have the windows.h header file. */
+/* #undef HAVE_WINDOWS_H */
+
+/* Define to 1 if you have the winsock2.h header file. */
+/* #undef HAVE_WINSOCK2_H */
+
+/* Define to 1 if you have the winsock.h header file. */
+/* #undef HAVE_WINSOCK_H */
+
+/* Define to 1 if you have the writev function. */
+#define HAVE_WRITEV
+
+/* Define to 1 if you have the ws2tcpip.h header file. */
+/* #undef HAVE_WS2TCPIP_H */
+
+/* Define if __system_property_get exists. */
+/* #undef HAVE___SYSTEM_PROPERTY_GET */
+
+/* Define to 1 if you need the malloc.h header file even with stdlib.h */
+/* #undef NEED_MALLOC_H */
+
+/* Define to 1 if you need the memory.h header file even with stdlib.h */
+/* #undef NEED_MEMORY_H */
+
+/* a suitable file/device to read random data from */
+/* #undef RANDOM_FILE */
+
+/* Define to the type qualifier pointed by arg 5 for recvfrom. */
+#define RECVFROM_QUAL_ARG5 
+
+/* Define to the type of arg 1 for recvfrom. */
+#define RECVFROM_TYPE_ARG1 int
+
+/* Define to the type pointed by arg 2 for recvfrom. */
+#define RECVFROM_TYPE_ARG2 void *
+
+/* Define to 1 if the type pointed by arg 2 for recvfrom is void. */
+#define RECVFROM_TYPE_ARG2_IS_VOID 0
+
+/* Define to the type of arg 3 for recvfrom. */
+#define RECVFROM_TYPE_ARG3 size_t
+
+/* Define to the type of arg 4 for recvfrom. */
+#define RECVFROM_TYPE_ARG4 int
+
+/* Define to the type pointed by arg 5 for recvfrom. */
+#define RECVFROM_TYPE_ARG5 struct sockaddr *
+
+/* Define to 1 if the type pointed by arg 5 for recvfrom is void. */
+#define RECVFROM_TYPE_ARG5_IS_VOID 0
+
+/* Define to the type pointed by arg 6 for recvfrom. */
+#define RECVFROM_TYPE_ARG6 socklen_t *
+
+/* Define to 1 if the type pointed by arg 6 for recvfrom is void. */
+#define RECVFROM_TYPE_ARG6_IS_VOID 0
+
+/* Define to the function return type for recvfrom. */
+#define RECVFROM_TYPE_RETV ssize_t
+
+/* Define to the type of arg 1 for recv. */
+#define RECV_TYPE_ARG1 int
+
+/* Define to the type of arg 2 for recv. */
+#define RECV_TYPE_ARG2 void *
+
+/* Define to the type of arg 3 for recv. */
+#define RECV_TYPE_ARG3 size_t
+
+/* Define to the type of arg 4 for recv. */
+#define RECV_TYPE_ARG4 int
+
+/* Define to the function return type for recv. */
+#define RECV_TYPE_RETV ssize_t
+
+/* Define as the return type of signal handlers (`int' or `void'). */
+#define RETSIGTYPE 
+
+/* Define to the type qualifier of arg 2 for send. */
+#define SEND_QUAL_ARG2 
+
+/* Define to the type of arg 1 for send. */
+#define SEND_TYPE_ARG1 int
+
+/* Define to the type of arg 2 for send. */
+#define SEND_TYPE_ARG2 void *
+
+/* Define to the type of arg 3 for send. */
+#define SEND_TYPE_ARG3 size_t
+
+/* Define to the type of arg 4 for send. */
+#define SEND_TYPE_ARG4 int
+
+/* Define to the function return type for send. */
+#define SEND_TYPE_RETV ssize_t
+
+/* Define to 1 if you can safely include both <sys/time.h> and <time.h>. */
+#define TIME_WITH_SYS_TIME
+
+/* Define to disable non-blocking sockets. */
+#undef USE_BLOCKING_SOCKETS
+
+/* Define to avoid automatic inclusion of winsock.h */
+#undef WIN32_LEAN_AND_MEAN
+
+/* Type to use in place of in_addr_t when system does not provide it. */
+#undef in_addr_t
+

--- a/third_party/cares/config_linux/ares_config.h
+++ b/third_party/cares/config_linux/ares_config.h
@@ -1,5 +1,3 @@
-// https://github.com/grpc/grpc/blob/master/third_party/cares/config_linux/ares_config.h
-
 /* Generated from ares_config.h.cmake*/
 
 /* Define if building universal (internal helper macro) */
@@ -30,10 +28,10 @@
 #define GETHOSTNAME_TYPE_ARG2 size_t
 
 /* Define to the type qualifier of arg 1 for getnameinfo. */
-#define GETNAMEINFO_QUAL_ARG1
+#define GETNAMEINFO_QUAL_ARG1 
 
 /* Define to the type of arg 1 for getnameinfo. */
-#define GETNAMEINFO_TYPE_ARG1 struct sockaddr*
+#define GETNAMEINFO_TYPE_ARG1 struct sockaddr *
 
 /* Define to the type of arg 2 for getnameinfo. */
 #define GETNAMEINFO_TYPE_ARG2 socklen_t
@@ -75,7 +73,7 @@
  * Note: setting HAVE_CLOCK_GETTIME_MONOTONIC causes use of the clock_gettime
  * function from glibc, don't set it to support glibc < 2.17 */
 #ifndef GPR_BACKWARDS_COMPATIBILITY_MODE
-#define HAVE_CLOCK_GETTIME_MONOTONIC
+  #define HAVE_CLOCK_GETTIME_MONOTONIC
 #endif
 
 /* Define to 1 if you have the closesocket function. */
@@ -160,7 +158,7 @@
 /* #undef HAVE_IOCTLSOCKET_CAMEL */
 
 /* Define to 1 if you have a working IoctlSocket camel case FIONBIO function.
- */
+   */
 /* #undef HAVE_IOCTLSOCKET_CAMEL_FIONBIO */
 
 /* Define to 1 if you have a working ioctlsocket FIONBIO function. */
@@ -353,13 +351,13 @@
 /* #undef RANDOM_FILE */
 
 /* Define to the type qualifier pointed by arg 5 for recvfrom. */
-#define RECVFROM_QUAL_ARG5
+#define RECVFROM_QUAL_ARG5 
 
 /* Define to the type of arg 1 for recvfrom. */
 #define RECVFROM_TYPE_ARG1 int
 
 /* Define to the type pointed by arg 2 for recvfrom. */
-#define RECVFROM_TYPE_ARG2 void*
+#define RECVFROM_TYPE_ARG2 void *
 
 /* Define to 1 if the type pointed by arg 2 for recvfrom is void. */
 #define RECVFROM_TYPE_ARG2_IS_VOID 0
@@ -371,13 +369,13 @@
 #define RECVFROM_TYPE_ARG4 int
 
 /* Define to the type pointed by arg 5 for recvfrom. */
-#define RECVFROM_TYPE_ARG5 struct sockaddr*
+#define RECVFROM_TYPE_ARG5 struct sockaddr *
 
 /* Define to 1 if the type pointed by arg 5 for recvfrom is void. */
 #define RECVFROM_TYPE_ARG5_IS_VOID 0
 
 /* Define to the type pointed by arg 6 for recvfrom. */
-#define RECVFROM_TYPE_ARG6 socklen_t*
+#define RECVFROM_TYPE_ARG6 socklen_t *
 
 /* Define to 1 if the type pointed by arg 6 for recvfrom is void. */
 #define RECVFROM_TYPE_ARG6_IS_VOID 0
@@ -389,7 +387,7 @@
 #define RECV_TYPE_ARG1 int
 
 /* Define to the type of arg 2 for recv. */
-#define RECV_TYPE_ARG2 void*
+#define RECV_TYPE_ARG2 void *
 
 /* Define to the type of arg 3 for recv. */
 #define RECV_TYPE_ARG3 size_t
@@ -401,16 +399,16 @@
 #define RECV_TYPE_RETV ssize_t
 
 /* Define as the return type of signal handlers (`int' or `void'). */
-#define RETSIGTYPE
+#define RETSIGTYPE 
 
 /* Define to the type qualifier of arg 2 for send. */
-#define SEND_QUAL_ARG2
+#define SEND_QUAL_ARG2 
 
 /* Define to the type of arg 1 for send. */
 #define SEND_TYPE_ARG1 int
 
 /* Define to the type of arg 2 for send. */
-#define SEND_TYPE_ARG2 void*
+#define SEND_TYPE_ARG2 void *
 
 /* Define to the type of arg 3 for send. */
 #define SEND_TYPE_ARG3 size_t
@@ -434,30 +432,30 @@
 #undef in_addr_t
 
 #ifdef GPR_BACKWARDS_COMPATIBILITY_MODE
-/* IMPORTANT: gRPC MANUAL EDIT HERE!
- * Redefine the fd_set macros for GLIBC < 2.15 support.
- * This is a backwards compatibility hack. At version 2.15, GLIBC introduces
- * the __fdelt_chk function, and starts using it within its fd_set macros
- * (which c-ares uses). For compatibility with GLIBC < 2.15, we need to redefine
- * the fd_set macros to not use __fdelt_chk. */
-#include <sys/select.h>
-#undef FD_SET
-#undef FD_CLR
-#undef FD_ISSET
-/* 'FD_ZERO' doesn't use __fdelt_chk, no need to redefine. */
+  /* IMPORTANT: gRPC MANUAL EDIT HERE!
+   * Redefine the fd_set macros for GLIBC < 2.15 support.
+   * This is a backwards compatibility hack. At version 2.15, GLIBC introduces
+   * the __fdelt_chk function, and starts using it within its fd_set macros
+   * (which c-ares uses). For compatibility with GLIBC < 2.15, we need to redefine
+   * the fd_set macros to not use __fdelt_chk. */
+  #include <sys/select.h>
+  #undef FD_SET
+  #undef FD_CLR
+  #undef FD_ISSET
+  /* 'FD_ZERO' doesn't use __fdelt_chk, no need to redefine. */
 
-#ifdef __FDS_BITS
-#define GRPC_CARES_FDS_BITS(set) __FDS_BITS(set)
-#else
-#define GRPC_CARES_FDS_BITS(set) ((set)->fds_bits)
-#endif
+  #ifdef __FDS_BITS
+    #define GRPC_CARES_FDS_BITS(set) __FDS_BITS(set)
+  #else
+    #define GRPC_CARES_FDS_BITS(set) ((set)->fds_bits)
+  #endif
 
-#define GRPC_CARES_FD_MASK(d) ((long int)(1UL << (d) % NFDBITS))
+  #define GRPC_CARES_FD_MASK(d) ((long int)(1UL << (d) % NFDBITS))
 
-#define FD_SET(d, set) \
-  ((void)(GRPC_CARES_FDS_BITS(set)[(d) / NFDBITS] |= GRPC_CARES_FD_MASK(d)))
-#define FD_CLR(d, set) \
-  ((void)(GRPC_CARES_FDS_BITS(set)[(d) / NFDBITS] &= ~GRPC_CARES_FD_MASK(d)))
-#define FD_ISSET(d, set) \
-  ((GRPC_CARES_FDS_BITS(set)[(d) / NFDBITS] & GRPC_CARES_FD_MASK(d)) != 0)
+  #define FD_SET(d, set) \
+      ((void) (GRPC_CARES_FDS_BITS (set)[ (d) / NFDBITS ] |= GRPC_CARES_FD_MASK(d)))
+  #define FD_CLR(d, set) \
+      ((void) (GRPC_CARES_FDS_BITS (set)[ (d) / NFDBITS ] &= ~GRPC_CARES_FD_MASK(d)))
+  #define FD_ISSET(d, set) \
+      ((GRPC_CARES_FDS_BITS (set)[ (d) / NFDBITS ] & GRPC_CARES_FD_MASK(d)) != 0)
 #endif /* GPR_BACKWARDS_COMPATIBILITY_MODE */

--- a/third_party/cares/config_windows/ares_config.h
+++ b/third_party/cares/config_windows/ares_config.h
@@ -1,0 +1,426 @@
+/* Generated from ares_config.h.cmake*/
+
+/* Define if building universal (internal helper macro) */
+#undef AC_APPLE_UNIVERSAL_BUILD
+
+/* define this if ares is built for a big endian system */
+#undef ARES_BIG_ENDIAN
+
+/* when building as static part of libcurl */
+#undef BUILDING_LIBCURL
+
+/* Defined for build that exposes internal static functions for testing. */
+#undef CARES_EXPOSE_STATICS
+
+/* Defined for build with symbol hiding. */
+#undef CARES_SYMBOL_HIDING
+
+/* Definition to make a library symbol externally visible. */
+#undef CARES_SYMBOL_SCOPE_EXTERN
+
+/* Use resolver library to configure cares */
+/* #undef CARES_USE_LIBRESOLV */
+
+/* if a /etc/inet dir is being used */
+#undef ETC_INET
+
+/* Define to the type of arg 2 for gethostname. */
+#define GETHOSTNAME_TYPE_ARG2 int
+
+/* Define to the type qualifier of arg 1 for getnameinfo. */
+#define GETNAMEINFO_QUAL_ARG1 
+
+/* Define to the type of arg 1 for getnameinfo. */
+#define GETNAMEINFO_TYPE_ARG1 struct sockaddr *
+
+/* Define to the type of arg 2 for getnameinfo. */
+#define GETNAMEINFO_TYPE_ARG2 socklen_t
+
+/* Define to the type of args 4 and 6 for getnameinfo. */
+#define GETNAMEINFO_TYPE_ARG46 socklen_t
+
+/* Define to the type of arg 7 for getnameinfo. */
+#define GETNAMEINFO_TYPE_ARG7 int
+
+/* Specifies the number of arguments to getservbyport_r */
+#define GETSERVBYPORT_R_ARGS 
+
+/* Define to 1 if you have AF_INET6. */
+#define HAVE_AF_INET6
+
+/* Define to 1 if you have the <arpa/inet.h> header file. */
+/* #undef HAVE_ARPA_INET_H */
+
+/* Define to 1 if you have the <arpa/nameser_compat.h> header file. */
+/* #undef HAVE_ARPA_NAMESER_COMPAT_H */
+
+/* Define to 1 if you have the <arpa/nameser.h> header file. */
+/* #undef HAVE_ARPA_NAMESER_H */
+
+/* Define to 1 if you have the <assert.h> header file. */
+#define HAVE_ASSERT_H
+
+/* Define to 1 if you have the `bitncmp' function. */
+/* #undef HAVE_BITNCMP */
+
+/* Define to 1 if bool is an available type. */
+#define HAVE_BOOL_T
+
+/* Define to 1 if you have the clock_gettime function and monotonic timer. */
+/* #undef HAVE_CLOCK_GETTIME_MONOTONIC */
+
+/* Define to 1 if you have the closesocket function. */
+#define HAVE_CLOSESOCKET
+
+/* Define to 1 if you have the CloseSocket camel case function. */
+/* #undef HAVE_CLOSESOCKET_CAMEL */
+
+/* Define to 1 if you have the connect function. */
+#define HAVE_CONNECT
+
+/* define if the compiler supports basic C++11 syntax */
+/* #undef HAVE_CXX11 */
+
+/* Define to 1 if you have the <dlfcn.h> header file. */
+/* #undef HAVE_DLFCN_H */
+
+/* Define to 1 if you have the <errno.h> header file. */
+#define HAVE_ERRNO_H
+
+/* Define to 1 if you have the fcntl function. */
+/* #undef HAVE_FCNTL */
+
+/* Define to 1 if you have the <fcntl.h> header file. */
+#define HAVE_FCNTL_H
+
+/* Define to 1 if you have a working fcntl O_NONBLOCK function. */
+/* #undef HAVE_FCNTL_O_NONBLOCK */
+
+/* Define to 1 if you have the freeaddrinfo function. */
+#define HAVE_FREEADDRINFO
+
+/* Define to 1 if you have a working getaddrinfo function. */
+#define HAVE_GETADDRINFO
+
+/* Define to 1 if the getaddrinfo function is threadsafe. */
+#define HAVE_GETADDRINFO_THREADSAFE
+
+/* Define to 1 if you have the getenv function. */
+#define HAVE_GETENV
+
+/* Define to 1 if you have the gethostbyaddr function. */
+#define HAVE_GETHOSTBYADDR
+
+/* Define to 1 if you have the gethostbyname function. */
+#define HAVE_GETHOSTBYNAME
+
+/* Define to 1 if you have the gethostname function. */
+#define HAVE_GETHOSTNAME
+
+/* Define to 1 if you have the getnameinfo function. */
+#define HAVE_GETNAMEINFO
+
+/* Define to 1 if you have the getservbyport_r function. */
+/* #undef HAVE_GETSERVBYPORT_R */
+
+/* Define to 1 if you have the `gettimeofday' function. */
+/* #undef HAVE_GETTIMEOFDAY */
+
+/* Define to 1 if you have the `if_indextoname' function. */
+/* #undef HAVE_IF_INDEXTONAME */
+
+/* Define to 1 if you have a IPv6 capable working inet_net_pton function. */
+/* #undef HAVE_INET_NET_PTON */
+
+/* Define to 1 if you have a IPv6 capable working inet_ntop function. */
+/* #undef HAVE_INET_NTOP */
+
+/* Define to 1 if you have a IPv6 capable working inet_pton function. */
+/* #undef HAVE_INET_PTON */
+
+/* Define to 1 if you have the <inttypes.h> header file. */
+#define HAVE_INTTYPES_H
+
+/* Define to 1 if you have the ioctl function. */
+/* #undef HAVE_IOCTL */
+
+/* Define to 1 if you have the ioctlsocket function. */
+#define HAVE_IOCTLSOCKET
+
+/* Define to 1 if you have the IoctlSocket camel case function. */
+/* #undef HAVE_IOCTLSOCKET_CAMEL */
+
+/* Define to 1 if you have a working IoctlSocket camel case FIONBIO function.
+   */
+/* #undef HAVE_IOCTLSOCKET_CAMEL_FIONBIO */
+
+/* Define to 1 if you have a working ioctlsocket FIONBIO function. */
+#define HAVE_IOCTLSOCKET_FIONBIO
+
+/* Define to 1 if you have a working ioctl FIONBIO function. */
+/* #undef HAVE_IOCTL_FIONBIO */
+
+/* Define to 1 if you have a working ioctl SIOCGIFADDR function. */
+/* #undef HAVE_IOCTL_SIOCGIFADDR */
+
+/* Define to 1 if you have the `resolve' library (-lresolve). */
+/* #undef HAVE_LIBRESOLV */
+
+/* Define to 1 if you have the <limits.h> header file. */
+#define HAVE_LIMITS_H
+
+/* if your compiler supports LL */
+#define HAVE_LL
+
+/* Define to 1 if the compiler supports the 'long long' data type. */
+#define HAVE_LONGLONG
+
+/* Define to 1 if you have the malloc.h header file. */
+#define HAVE_MALLOC_H
+
+/* Define to 1 if you have the memory.h header file. */
+#define HAVE_MEMORY_H
+
+/* Define to 1 if you have the MSG_NOSIGNAL flag. */
+/* #undef HAVE_MSG_NOSIGNAL */
+
+/* Define to 1 if you have the <netdb.h> header file. */
+/* #undef HAVE_NETDB_H */
+
+/* Define to 1 if you have the <netinet/in.h> header file. */
+/* #undef HAVE_NETINET_IN_H */
+
+/* Define to 1 if you have the <netinet/tcp.h> header file. */
+/* #undef HAVE_NETINET_TCP_H */
+
+/* Define to 1 if you have the <net/if.h> header file. */
+/* #undef HAVE_NET_IF_H */
+
+/* Define to 1 if you have PF_INET6. */
+#define HAVE_PF_INET6
+
+/* Define to 1 if you have the recv function. */
+#define HAVE_RECV
+
+/* Define to 1 if you have the recvfrom function. */
+#define HAVE_RECVFROM
+
+/* Define to 1 if you have the send function. */
+#define HAVE_SEND
+
+/* Define to 1 if you have the setsockopt function. */
+#define HAVE_SETSOCKOPT
+
+/* Define to 1 if you have a working setsockopt SO_NONBLOCK function. */
+/* #undef HAVE_SETSOCKOPT_SO_NONBLOCK */
+
+/* Define to 1 if you have the <signal.h> header file. */
+#define HAVE_SIGNAL_H
+
+/* Define to 1 if sig_atomic_t is an available typedef. */
+#define HAVE_SIG_ATOMIC_T
+
+/* Define to 1 if sig_atomic_t is already defined as volatile. */
+/* #undef HAVE_SIG_ATOMIC_T_VOLATILE */
+
+/* Define to 1 if your struct sockaddr_in6 has sin6_scope_id. */
+#define HAVE_SOCKADDR_IN6_SIN6_SCOPE_ID
+
+/* Define to 1 if you have the socket function. */
+#define HAVE_SOCKET
+
+/* Define to 1 if you have the <socket.h> header file. */
+/* #undef HAVE_SOCKET_H */
+
+/* Define to 1 if you have the <stdbool.h> header file. */
+#define HAVE_STDBOOL_H
+
+/* Define to 1 if you have the <stdint.h> header file. */
+#define HAVE_STDINT_H
+
+/* Define to 1 if you have the <stdlib.h> header file. */
+#define HAVE_STDLIB_H
+
+/* Define to 1 if you have the strcasecmp function. */
+/* #undef HAVE_STRCASECMP */
+
+/* Define to 1 if you have the strcmpi function. */
+#define HAVE_STRCMPI
+
+/* Define to 1 if you have the strdup function. */
+#define HAVE_STRDUP
+
+/* Define to 1 if you have the stricmp function. */
+#define HAVE_STRICMP
+
+/* Define to 1 if you have the <strings.h> header file. */
+/* #undef HAVE_STRINGS_H */
+
+/* Define to 1 if you have the <string.h> header file. */
+#define HAVE_STRING_H
+
+/* Define to 1 if you have the strncasecmp function. */
+/* #undef HAVE_STRNCASECMP */
+
+/* Define to 1 if you have the strncmpi function. */
+/* #undef HAVE_STRNCMPI */
+
+/* Define to 1 if you have the strnicmp function. */
+#define HAVE_STRNICMP
+
+/* Define to 1 if you have the <stropts.h> header file. */
+/* #undef HAVE_STROPTS_H */
+
+/* Define to 1 if you have struct addrinfo. */
+#define HAVE_STRUCT_ADDRINFO
+
+/* Define to 1 if you have struct in6_addr. */
+#define HAVE_STRUCT_IN6_ADDR
+
+/* Define to 1 if you have struct sockaddr_in6. */
+#define HAVE_STRUCT_SOCKADDR_IN6
+
+/* if struct sockaddr_storage is defined */
+#define HAVE_STRUCT_SOCKADDR_STORAGE
+
+/* Define to 1 if you have the timeval struct. */
+#define HAVE_STRUCT_TIMEVAL
+
+/* Define to 1 if you have the <sys/ioctl.h> header file. */
+/* #undef HAVE_SYS_IOCTL_H */
+
+/* Define to 1 if you have the <sys/param.h> header file. */
+/* #undef HAVE_SYS_PARAM_H */
+
+/* Define to 1 if you have the <sys/select.h> header file. */
+/* #undef HAVE_SYS_SELECT_H */
+
+/* Define to 1 if you have the <sys/socket.h> header file. */
+/* #undef HAVE_SYS_SOCKET_H */
+
+/* Define to 1 if you have the <sys/stat.h> header file. */
+#define HAVE_SYS_STAT_H
+
+/* Define to 1 if you have the <sys/time.h> header file. */
+/* #undef HAVE_SYS_TIME_H */
+
+/* Define to 1 if you have the <sys/types.h> header file. */
+#define HAVE_SYS_TYPES_H
+
+/* Define to 1 if you have the <sys/uio.h> header file. */
+/* #undef HAVE_SYS_UIO_H */
+
+/* Define to 1 if you have the <time.h> header file. */
+#define HAVE_TIME_H
+
+/* Define to 1 if you have the <unistd.h> header file. */
+/* #undef HAVE_UNISTD_H */
+
+/* Define to 1 if you have the windows.h header file. */
+#define HAVE_WINDOWS_H
+
+/* Define to 1 if you have the winsock2.h header file. */
+#define HAVE_WINSOCK2_H
+
+/* Define to 1 if you have the winsock.h header file. */
+#define HAVE_WINSOCK_H
+
+/* Define to 1 if you have the writev function. */
+/* #undef HAVE_WRITEV */
+
+/* Define to 1 if you have the ws2tcpip.h header file. */
+#define HAVE_WS2TCPIP_H
+
+/* Define if __system_property_get exists. */
+/* #undef HAVE___SYSTEM_PROPERTY_GET */
+
+/* Define to 1 if you need the malloc.h header file even with stdlib.h */
+/* #undef NEED_MALLOC_H */
+
+/* Define to 1 if you need the memory.h header file even with stdlib.h */
+/* #undef NEED_MEMORY_H */
+
+/* a suitable file/device to read random data from */
+/* #undef RANDOM_FILE */
+
+/* Define to the type qualifier pointed by arg 5 for recvfrom. */
+#define RECVFROM_QUAL_ARG5 
+
+/* Define to the type of arg 1 for recvfrom. */
+#define RECVFROM_TYPE_ARG1 SOCKET
+
+/* Define to the type pointed by arg 2 for recvfrom. */
+#define RECVFROM_TYPE_ARG2 void *
+
+/* Define to 1 if the type pointed by arg 2 for recvfrom is void. */
+#define RECVFROM_TYPE_ARG2_IS_VOID 0
+
+/* Define to the type of arg 3 for recvfrom. */
+#define RECVFROM_TYPE_ARG3 int
+
+/* Define to the type of arg 4 for recvfrom. */
+#define RECVFROM_TYPE_ARG4 int
+
+/* Define to the type pointed by arg 5 for recvfrom. */
+#define RECVFROM_TYPE_ARG5 struct sockaddr *
+
+/* Define to 1 if the type pointed by arg 5 for recvfrom is void. */
+#define RECVFROM_TYPE_ARG5_IS_VOID 0
+
+/* Define to the type pointed by arg 6 for recvfrom. */
+#define RECVFROM_TYPE_ARG6 socklen_t *
+
+/* Define to 1 if the type pointed by arg 6 for recvfrom is void. */
+#define RECVFROM_TYPE_ARG6_IS_VOID 0
+
+/* Define to the function return type for recvfrom. */
+#define RECVFROM_TYPE_RETV int
+
+/* Define to the type of arg 1 for recv. */
+#define RECV_TYPE_ARG1 SOCKET
+
+/* Define to the type of arg 2 for recv. */
+#define RECV_TYPE_ARG2 void *
+
+/* Define to the type of arg 3 for recv. */
+#define RECV_TYPE_ARG3 int
+
+/* Define to the type of arg 4 for recv. */
+#define RECV_TYPE_ARG4 int
+
+/* Define to the function return type for recv. */
+#define RECV_TYPE_RETV int
+
+/* Define as the return type of signal handlers (`int' or `void'). */
+#define RETSIGTYPE 
+
+/* Define to the type qualifier of arg 2 for send. */
+#define SEND_QUAL_ARG2 
+
+/* Define to the type of arg 1 for send. */
+#define SEND_TYPE_ARG1 SOCKET
+
+/* Define to the type of arg 2 for send. */
+#define SEND_TYPE_ARG2 void *
+
+/* Define to the type of arg 3 for send. */
+#define SEND_TYPE_ARG3 int
+
+/* Define to the type of arg 4 for send. */
+#define SEND_TYPE_ARG4 int
+
+/* Define to the function return type for send. */
+#define SEND_TYPE_RETV int
+
+/* Define to 1 if you can safely include both <sys/time.h> and <time.h>. */
+/* #undef TIME_WITH_SYS_TIME */
+
+/* Define to disable non-blocking sockets. */
+#undef USE_BLOCKING_SOCKETS
+
+/* Define to avoid automatic inclusion of winsock.h */
+#undef WIN32_LEAN_AND_MEAN
+
+/* Type to use in place of in_addr_t when system does not provide it. */
+#undef in_addr_t
+


### PR DESCRIPTION
This allows building spectator-cpp on OSX using bazel. Useful for
projects that depends on this library using that build system.

It can be added as a dependency using something like:

```
http_archive(
      name = "spectator",
      urls = ["https://github.com/Netflix/spectator-cpp/archive/v0.7.6.tar.gz"],
      sha256 = "b064f520ab61102f2f6bc82b4a89de735393d0c679d2ac1cd142602d60ee16da",
      strip_prefix = "spectator-cpp-0.7.6"
  )
```

Previously it would fail due to the c-ares dependency having a
hard-coded config for linux. On OSX there is no `MSG_NOSIGNAL`
identifier, which causes the c-ares build to fail with:

```
external/com_github_c_ares_c_ares/ares_process.c:199:10: error: use of undeclared identifier 'MSG_NOSIGNAL'
  return swrite(s, data, len);
         ^
external/com_github_c_ares_c_ares/setup_once.h:204:54: note: expanded from macro 'swrite'
                                    (SEND_TYPE_ARG4)(SEND_4TH_ARG))
                                                     ^
external/com_github_c_ares_c_ares/setup_once.h:126:22: note: expanded from macro 'SEND_4TH_ARG'
                     ^
```

This patch also includes the config for Windows which would make it
possible to build spectator-cpp on that platform (but that is untested
and unsupported)