### PR TITLE
Avoid crash if the registry is started at shutdown

### DIFF
--- a/spectator/publisher.h
+++ b/spectator/publisher.h
@@ -15,6 +15,12 @@ class Publisher {
  public:
   explicit Publisher(R* registry)
       : registry_(registry), started_{false}, should_stop_{false} {}
+  Publisher(const Publisher&) = delete;
+  ~Publisher() {
+    if (started_) {
+      Stop();
+    }
+  }
   void Start() {
     if (!http_initialized_) {
       http_initialized_ = true;

--- a/spectator/registry.cc
+++ b/spectator/registry.cc
@@ -14,7 +14,7 @@ const Config& Registry::GetConfig() const noexcept { return *config_; }
 
 Registry::logger_ptr Registry::GetLogger() const noexcept { return logger_; }
 
-IdPtr Registry::CreateId(std::string name, Tags tags) noexcept {
+IdPtr Registry::CreateId(std::string name, Tags tags) const noexcept {
   return std::make_shared<Id>(name, tags);
 }
 

--- a/spectator/registry.h
+++ b/spectator/registry.h
@@ -21,7 +21,7 @@ class Registry {
   const Config& GetConfig() const noexcept;
   logger_ptr GetLogger() const noexcept;
 
-  IdPtr CreateId(std::string name, Tags tags) noexcept;
+  IdPtr CreateId(std::string name, Tags tags) const noexcept;
 
   std::shared_ptr<Counter> GetCounter(IdPtr id) noexcept;
   std::shared_ptr<Counter> GetCounter(std::string name) noexcept;

--- a/third_party/curl.BUILD
+++ b/third_party/curl.BUILD
@@ -3,6 +3,12 @@
 # Description:
 #   curl is a tool for talking to web servers.
 
+config_setting(
+    name = "darwin",
+    values = {"cpu": "darwin"},
+)
+
+
 licenses(["notice"])  # MIT/X derivative license
 
 exports_files(["COPYING"])
@@ -260,6 +266,12 @@ cc_library(
     defines = ["CURL_STATICLIB"],
     includes = ["include"],
     linkopts = select({
+        "darwin": [
+                    "-Wl,-framework",
+                    "-Wl,CoreFoundation",
+                    "-Wl,-framework",
+                    "-Wl,Security",
+                ],
         "//conditions:default": [
             "-lrt",
         ],


### PR DESCRIPTION
Call `Stop()` from the publisher destructor in case the user fails to
manually call `Stop()` on a started Registry.

Additionally add some minor tweaks:

- Mark `Registry.CreateId` const

- Avoid attempting to link curl against `-lrt` on OSX when using bazel