### PR TITLE
Add sectransp to the curl bazel build for OSX

### DIFF
--- a/third_party/curl.BUILD
+++ b/third_party/curl.BUILD
@@ -230,6 +230,9 @@ cc_library(
         "lib/doh.h",
         "lib/doh.c",
     ] + select({
+        "darwin": [
+            "lib/vtls/sectransp.c",
+        ],
         "//conditions:default": [
             "lib/vtls/openssl.c",
         ],


### PR DESCRIPTION
Otherwise our tests would fail with:

```
dyld: Symbol not found: _Curl_ssl_sectransp
```