### PR TITLE
Benchmark to test different Tags implementations

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -92,3 +92,13 @@ cc_test(
         "@com_github_tessil_hopscotch_map//:hopscotch_map",
       ]
     )
+
+cc_test(
+    name = "tags_bench",
+    srcs = ["bench/bench_tags.cc",],
+    deps = [
+        ":spectator",
+        "@com_google_benchmark//:benchmark",
+        "@com_github_tessil_hopscotch_map//:hopscotch_map",
+      ]
+    )

--- a/bench/README.md
+++ b/bench/README.md
@@ -7,8 +7,8 @@
 bazel test -c opt tables_bench --test_output=all
 ```
 
-On my system it shows a significant performance advantage by using `tsl::hopscotch_map` 
-enabling storing the hash on the table (helps during resizing). 
+On my system it shows a significant performance advantage by using `tsl::hopscotch_map`
+enabling storing the hash on the table (helps during resizing).
 Testing with different number of meters shows:
 
 ```
@@ -40,4 +40,90 @@ BM_HopscotchMapHash/8              969 ns          969 ns       718416
 BM_HopscotchMapHash/256            978 ns          978 ns       715589
 BM_HopscotchMapHash/65536         1448 ns         1448 ns       524299
 BM_HopscotchMapHash/8388608       1491 ns         1491 ns       606882
+```
+
+## Benchmarking different implementations for tags
+
+```
+bazel test -c opt tags_bench --test_output=all
+```
+
+This tests different hash table implementations to maintain the key/values for tags.
+The first parameterized test uses 4 key/values times the input so a `/4` is a test
+maintaining a 16 entry tag set. 3/4 of those key/values are small strings (which could have
+different behavior thanks to the small string optimization usual in `std::string`
+implementations.)
+
+In general our current `ska::flat_hash_map` has roughly
+the same performance as the `hopscotch` based tables but is significantly faster when
+starting from a given set of tags which is the behavior we experience when we start with
+a base-id and add tags to it.
+
+```
+g++ 7 on bionic
+
+Run on (4 X 2936.1 MHz CPU s)
+CPU Caches:
+  L1 Data 32K (x2)
+  L1 Instruction 32K (x2)
+  L2 Unified 1024K (x2)
+  L3 Unified 33792K (x1)
+Load Average: 1.95, 2.14, 1.29
+---------------------------------------------------------------------
+Benchmark                           Time             CPU   Iterations
+---------------------------------------------------------------------
+BM_UnorderedMap/1                 405 ns          405 ns      1726676
+BM_UnorderedMap/2                 830 ns          830 ns       842982
+BM_UnorderedMap/4                1776 ns         1776 ns       393477
+BM_UnorderedMap/8                3580 ns         3580 ns       195222
+BM_FlatHashMap/1                  350 ns          350 ns      1998110
+BM_FlatHashMap/2                  757 ns          757 ns       911140
+BM_FlatHashMap/4                 1512 ns         1512 ns       458092
+BM_FlatHashMap/8                 2976 ns         2976 ns       235218
+BM_HopscotchMap/1                 358 ns          358 ns      1955560
+BM_HopscotchMap/2                 753 ns          753 ns       931632
+BM_HopscotchMap/4                1556 ns         1556 ns       441878
+BM_HopscotchMap/8                3054 ns         3054 ns       226568
+BM_HopscotchMapHash/1             353 ns          353 ns      1983117
+BM_HopscotchMapHash/2             729 ns          729 ns       961091
+BM_HopscotchMapHash/4            1530 ns         1530 ns       460196
+BM_HopscotchMapHash/8            2916 ns         2916 ns       239604
+BM_UnorderedMapWithTag            861 ns          862 ns       810127
+BM_FlatHashMapWithTag             860 ns          860 ns       815085
+BM_HopscotchMapWithTag           2147 ns         2147 ns       326313
+BM_HopscotchMapHashWithTag       1048 ns         1048 ns       668778
+================================================================================
+
+* Apple clang 11 on OSX Catalina
+
+CPU Caches:
+  L1 Data 32K (x8)
+  L1 Instruction 32K (x8)
+  L2 Unified 262K (x8)
+  L3 Unified 16777K (x1)
+Load Average: 1.94, 2.00, 2.11
+---------------------------------------------------------------------
+Benchmark                           Time             CPU   Iterations
+---------------------------------------------------------------------
+BM_UnorderedMap/1                 530 ns          529 ns      1183972
+BM_UnorderedMap/2                1090 ns         1090 ns       622698
+BM_UnorderedMap/4                2094 ns         2094 ns       328355
+BM_UnorderedMap/8                4382 ns         4374 ns       148945
+BM_FlatHashMap/1                  493 ns          492 ns      1423722
+BM_FlatHashMap/2                  985 ns          985 ns       716985
+BM_FlatHashMap/4                 1995 ns         1994 ns       355362
+BM_FlatHashMap/8                 3918 ns         3913 ns       176124
+BM_HopscotchMap/1                 491 ns          490 ns      1408720
+BM_HopscotchMap/2                1027 ns         1027 ns       658247
+BM_HopscotchMap/4                1988 ns         1987 ns       348618
+BM_HopscotchMap/8                4039 ns         4039 ns       177745
+BM_HopscotchMapHash/1             496 ns          496 ns      1331406
+BM_HopscotchMapHash/2            1067 ns         1066 ns       683120
+BM_HopscotchMapHash/4            1989 ns         1989 ns       354013
+BM_HopscotchMapHash/8            3986 ns         3985 ns       174339
+BM_UnorderedMapWithTag           2062 ns         2062 ns       344887
+BM_FlatHashMapWithTag             799 ns          799 ns       812829
+BM_HopscotchMapWithTag           1971 ns         1970 ns       359683
+BM_HopscotchMapHashWithTag       1313 ns         1312 ns       540011
+================================================================================
 ```

--- a/bench/bench_tags.cc
+++ b/bench/bench_tags.cc
@@ -1,0 +1,164 @@
+// Benchmarks different implementations for Tags
+
+#include <benchmark/benchmark.h>
+#include <fmt/format.h>
+#include <ska/flat_hash_map.hpp>
+#include <tsl/hopscotch_map.h>
+#include <unordered_map>
+
+template <typename C>
+class Tags {
+  using K = std::string;
+  using V = std::string;
+  C entries_;
+
+ public:
+  Tags() = default;
+  Tags(const Tags& other) = default;
+
+  Tags(std::initializer_list<std::pair<std::string, std::string>> vs) {
+    for (auto& pair : vs) {
+      add(std::move(pair.first), std::move(pair.second));
+    }
+  }
+
+  void add(K k, V v) { entries_[std::move(k)] = std::move(v); }
+
+  size_t hash() const {
+    size_t h = 0;
+    for (const auto& entry : entries_) {
+      h += (std::hash<K>()(entry.first) << 1) ^ std::hash<V>()(entry.second);
+    }
+    return h;
+  }
+
+  void add_all(const Tags<C>& source) {
+    for (const auto& t : source.entries_) {
+      entries_[t.first] = t.second;
+    }
+  }
+
+  bool operator==(const Tags<C>& that) const {
+    return that.entries_ == entries_;
+  }
+
+  bool has(const K& key) const { return entries_.find(key) != entries_.end(); }
+
+  K at(const K& key) const {
+    auto entry = entries_.find(key);
+    if (entry != entries_.end()) {
+      return entry->second;
+    }
+    return {};
+  }
+
+  size_t size() const { return entries_.size(); }
+
+  typename C::const_iterator begin() const { return entries_.begin(); }
+
+  typename C::const_iterator end() const { return entries_.end(); }
+};
+
+template <typename T>
+void add_tags(benchmark::State& state) {
+  Tags<T> tags;
+  for (auto _ : state) {
+    for (auto i = 0; i < state.range(0); ++i) {
+      // the majority of our tags usually fit in small strings
+      auto key1 = fmt::format("nf.1key{}", i);
+      auto key2 = fmt::format("nf.2key{}", i);
+      auto key3 = fmt::format("nf.3key{}", i);
+      // test how it behaves with a long string
+      auto long_key = fmt::format(
+          "some.longKey.value.that.does.not.fit.in.the.string.{}", i);
+
+      tags.add(key1, key1);
+      tags.add(key2, key2);
+      tags.add(key3, key3);
+      tags.add(long_key, long_key);
+    }
+  }
+}
+
+template <typename T>
+Tags<T> with_stat(const Tags<T>& source, const std::string& stat) {
+  Tags<T> copy{source};
+  copy.add("statistic", stat);
+  return copy;
+}
+
+// mimic the `id->WithTag()` functionality which is used very frequently, esp.
+// with the Measurements() functionality
+template <typename T>
+void with_tag(benchmark::State& state) {
+  Tags<T> tags{
+      {"name", "some.name"}, {"id", "some.id"}, {"dev", "root.device"}};
+
+  for (auto _ : state) {
+    // simulate a timer
+    benchmark::DoNotOptimize(with_stat(tags, "count"));
+    benchmark::DoNotOptimize(with_stat(tags, "totalTime"));
+    benchmark::DoNotOptimize(with_stat(tags, "totalOfSquares"));
+    benchmark::DoNotOptimize(with_stat(tags, "max"));
+  }
+}
+
+static void BM_FlatHashMap(benchmark::State& state) {
+  srand(1);
+  add_tags<ska::flat_hash_map<std::string, std::string>>(state);
+}
+
+static void BM_UnorderedMap(benchmark::State& state) {
+  srand(1);
+  add_tags<std::unordered_map<std::string, std::string>>(state);
+}
+
+static void BM_HopscotchMap(benchmark::State& state) {
+  srand(1);
+  using table_t = tsl::hopscotch_map<std::string, std::string>;
+  add_tags<table_t>(state);
+}
+
+static void BM_HopscotchMapHash(benchmark::State& state) {
+  srand(1);
+  // test storing the hash as part of the entry
+  using table_t =
+      tsl::hopscotch_map<std::string, std::string, std::hash<std::string>,
+                         std::equal_to<std::string>,
+                         std::allocator<std::pair<std::string, std::string>>, 4,
+                         true>;
+  add_tags<table_t>(state);
+}
+
+static void BM_UnorderedMapWithTag(benchmark::State& state) {
+  with_tag<std::unordered_map<std::string, std::string>>(state);
+}
+
+static void BM_FlatHashMapWithTag(benchmark::State& state) {
+  with_tag<ska::flat_hash_map<std::string, std::string>>(state);
+}
+
+static void BM_HopscotchMapWithTag(benchmark::State& state) {
+  with_tag<tsl::hopscotch_map<std::string, std::string>>(state);
+}
+
+static void BM_HopscotchMapHashWithTag(benchmark::State& state) {
+  using table_t =
+      tsl::hopscotch_map<std::string, std::string, std::hash<std::string>,
+                         std::equal_to<std::string>,
+                         std::allocator<std::pair<std::string, std::string>>, 4,
+                         true>;
+  with_tag<table_t>(state);
+}
+
+BENCHMARK(BM_UnorderedMap)->RangeMultiplier(2)->Range(1, 8);
+BENCHMARK(BM_FlatHashMap)->RangeMultiplier(2)->Range(1, 8);
+BENCHMARK(BM_HopscotchMap)->RangeMultiplier(2)->Range(1, 8);
+BENCHMARK(BM_HopscotchMapHash)->RangeMultiplier(2)->Range(1, 8);
+
+BENCHMARK(BM_UnorderedMapWithTag);
+BENCHMARK(BM_FlatHashMapWithTag);
+BENCHMARK(BM_HopscotchMapWithTag);
+BENCHMARK(BM_HopscotchMapHashWithTag);
+
+BENCHMARK_MAIN();

--- a/spectator/id.h
+++ b/spectator/id.h
@@ -17,12 +17,12 @@ class Tags {
   Tags() = default;
 
   Tags(std::initializer_list<std::pair<std::string, std::string>> vs) {
-    for (const auto& pair : vs) {
-      add(pair.first, pair.second);
+    for (auto& pair : vs) {
+      add(std::move(pair.first), std::move(pair.second));
     }
   }
 
-  void add(K k, V v) { entries_[k] = v; }
+  void add(K k, V v) { entries_[std::move(k)] = std::move(v); }
 
   size_t hash() const {
     size_t h = 0;


### PR DESCRIPTION
Test `std::unordered_map`, `ska::flat_hash_map`, `tsl::hopscotch_map` as
candidates for Tags implementations.

Our current implementation using `ska::flat_hash_map` is the fastest
currently.

While testing noticed that we could optimize the creation/add methods a
bit by moving the strings when possible.