### PR TITLE
Add sanitizer configurations

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -1,0 +1,36 @@
+# Address sanitizer
+# To use it: bazel build --config asan
+build:asan --strip=never
+build:asan --copt -fsanitize=address
+build:asan --copt -DADDRESS_SANITIZER
+build:asan --copt -O1
+build:asan --copt -g
+build:asan --copt -fno-omit-frame-pointer
+build:asan --linkopt -fsanitize=address
+
+# Thread sanitizer
+# bazel build --config tsan
+build:tsan --strip=never
+build:tsan --copt -fsanitize=thread
+build:tsan --copt -DTHREAD_SANITIZER
+build:tsan --copt -DDYNAMIC_ANNOTATIONS_ENABLED=1
+build:tsan --copt -DDYNAMIC_ANNOTATIONS_EXTERNAL_IMPL=1
+build:tsan --copt -O1
+build:tsan --copt -fno-omit-frame-pointer
+build:tsan --linkopt -fsanitize=thread
+
+# --config msan: Memory sanitizer
+build:msan --strip=never
+build:msan --copt -fsanitize=memory
+build:msan --copt -DADDRESS_SANITIZER
+build:msan --copt -O1
+build:msan --copt -fno-omit-frame-pointer
+build:msan --linkopt -fsanitize=memory
+
+# --config ubsan: Undefined Behavior Sanitizer
+build:ubsan --strip=never
+build:ubsan --copt -fsanitize=undefined
+build:ubsan --copt -O1
+build:ubsan --copt -fno-omit-frame-pointer
+build:ubsan --linkopt -fsanitize=undefined
+build:ubsan --linkopt -lubsan

--- a/test/publisher_test.cc
+++ b/test/publisher_test.cc
@@ -67,7 +67,7 @@ std::pair<int, payload_entry> get_entry(const std::vector<std::string>& strings,
 
 std::vector<payload_entry> payload_to_entries(
     const rapidjson::Document& payload) {
-  auto num_strings = payload[0].GetInt();
+  auto num_strings = static_cast<std::size_t>(payload[0].GetInt());
   std::vector<std::string> strings;
   strings.resize(num_strings);
   for (auto i = 1; i <= num_strings; ++i) {


### PR DESCRIPTION
Just double checking we're not failing any of the basic static analysis
provided by the sanitizers. Note that a few of these are only available
on linux.

* `--config asan` - Address sanitizer

* `--config tsan` - Thread sanitizer

* `--config msan` - Memory sanitizer

* `--config ubsan` - Undefined behavior sanitizer

For example to run the tests with the address sanitizer enabled:

```
bazel test -c dbg --config=asan  spectator_test --test_output=all
```