### PR TITLE
Expire inactive meters

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -34,3 +34,5 @@ build:ubsan --copt -O1
 build:ubsan --copt -fno-omit-frame-pointer
 build:ubsan --linkopt -fsanitize=undefined
 build:ubsan --linkopt -lubsan
+
+test --test_output=streamed

--- a/spectator/config.h
+++ b/spectator/config.h
@@ -14,18 +14,24 @@ class Config {
   Config(const Config&) = default;
 
   Config(std::map<std::string, std::string> c_tags, int read_to_ms,
-         int connect_to_ms, int batch_sz, int freq_ms, std::string publish_uri)
+         int connect_to_ms, int batch_sz, int freq_ms,
+         int exp_freq_ms, int meter_ttl_ms,
+         std::string publish_uri)
       : common_tags{std::move(c_tags)},
         read_timeout{std::chrono::milliseconds{read_to_ms}},
         connect_timeout{std::chrono::milliseconds{connect_to_ms}},
         batch_size{batch_sz},
         frequency{std::chrono::milliseconds{freq_ms}},
+        expiration_frequency{std::chrono::milliseconds{exp_freq_ms}},
+        meter_ttl{std::chrono::milliseconds{meter_ttl_ms}},
         uri{std::move(publish_uri)} {}
   std::map<std::string, std::string> common_tags;
   std::chrono::milliseconds read_timeout;
   std::chrono::milliseconds connect_timeout;
   int batch_size;
   std::chrono::milliseconds frequency;
+  std::chrono::milliseconds expiration_frequency;
+  std::chrono::milliseconds meter_ttl;
   std::string uri;
 
   // sub-classes can override this method implementing custom logic

--- a/spectator/counter.cc
+++ b/spectator/counter.cc
@@ -19,10 +19,11 @@ std::vector<Measurement> Counter::Measure() const noexcept {
 void Counter::Increment() noexcept { Add(1.0); }
 
 void Counter::Add(double delta) noexcept {
+  Update();
+
   if (delta < 0) {
     return;
   }
-
   add_double(&count_, delta);
 }
 

--- a/spectator/dist_summary.cc
+++ b/spectator/dist_summary.cc
@@ -27,6 +27,8 @@ std::vector<Measurement> DistributionSummary::Measure() const noexcept {
 }
 
 void DistributionSummary::Record(double amount) noexcept {
+  Update();
+
   if (amount >= 0) {
     count_.fetch_add(1, std::memory_order_relaxed);
     add_double(&total_, amount);

--- a/spectator/gauge.cc
+++ b/spectator/gauge.cc
@@ -17,6 +17,8 @@ std::vector<Measurement> Gauge::Measure() const noexcept {
 }
 
 void Gauge::Set(double value) noexcept {
+  Update();
+
   value_.store(value, std::memory_order_relaxed);
 }
 

--- a/spectator/max_gauge.cc
+++ b/spectator/max_gauge.cc
@@ -26,6 +26,9 @@ double MaxGauge::Get() const noexcept {
   return kNaN;
 }
 
-void MaxGauge::Update(double value) noexcept { update_max(&value_, value); }
+void MaxGauge::Update(double value) noexcept {
+  Meter::Update();
+  update_max(&value_, value);
+}
 
 }  // namespace spectator

--- a/spectator/meter.h
+++ b/spectator/meter.h
@@ -2,6 +2,7 @@
 
 #include "id.h"
 #include "measurement.h"
+#include <chrono>
 #include <vector>
 
 namespace spectator {

--- a/spectator/meter.h
+++ b/spectator/meter.h
@@ -45,6 +45,15 @@ class Meter {
   virtual IdPtr MeterId() const noexcept = 0;
   virtual std::vector<Measurement> Measure() const noexcept = 0;
   virtual MeterType GetType() const noexcept = 0;
+  std::chrono::system_clock::time_point Updated() const noexcept {
+    return last_updated_;
+  }
+
+ private:
+  std::chrono::system_clock::time_point last_updated_{};
+
+ protected:
+  void Update() { last_updated_ = std::chrono::system_clock::now(); }
 };
 
 }  // namespace spectator

--- a/spectator/monotonic_counter.cc
+++ b/spectator/monotonic_counter.cc
@@ -10,6 +10,7 @@ MonotonicCounter::MonotonicCounter(IdPtr id) noexcept
 IdPtr MonotonicCounter::MeterId() const noexcept { return id_; }
 
 void MonotonicCounter::Set(double amount) noexcept {
+  Update();
   value_.store(amount, std::memory_order_relaxed);
 }
 

--- a/spectator/registry.cc
+++ b/spectator/registry.cc
@@ -6,7 +6,9 @@ namespace spectator {
 
 Registry::Registry(std::unique_ptr<Config> config,
                    Registry::logger_ptr logger) noexcept
-    : config_{std::move(config)},
+    : should_stop_{true},
+      meter_ttl_{config->meter_ttl},
+      config_{std::move(config)},
       logger_{std::move(logger)},
       publisher_(this) {}
 
@@ -87,16 +89,45 @@ void Registry::log_type_error(const Id& id, MeterType prev_type,
       id, attempted_type, prev_type);
 }
 
-void Registry::Start() noexcept { publisher_.Start(); }
+void Registry::Start() noexcept {
+  publisher_.Start();
+  if (!should_stop_.exchange(false)) {
+    // already started
+    return;
+  }
 
-void Registry::Stop() noexcept { publisher_.Stop(); }
+  expirer_thread_ = std::thread(&Registry::expirer, this);
+}
+
+void Registry::Stop() noexcept {
+  publisher_.Stop();
+  if (!should_stop_.exchange(true)) {
+    logger_->debug("Stopping expirer thread");
+    cv_.notify_all();
+    expirer_thread_.join();
+  }
+}
+
+inline bool is_meter_expired(std::chrono::system_clock::time_point now,
+                             const Meter& m,
+                             std::chrono::milliseconds meter_ttl) {
+  if (meter_ttl.count() == 0) {
+    return false;
+  }
+  auto updated_ago = now - m.Updated();
+  return updated_ago > meter_ttl;
+}
 
 std::vector<Measurement> Registry::Measurements() const noexcept {
+  auto now = std::chrono::system_clock::now();
   std::vector<Measurement> res;
   std::lock_guard<std::mutex> lock{meters_mutex};
   for (const auto& pair : meters_) {
-    auto ms = pair.second->Measure();
-    std::move(ms.begin(), ms.end(), std::back_inserter(res));
+    const auto& m = *pair.second;
+    if (!is_meter_expired(now, m, meter_ttl_)) {
+      auto ms = m.Measure();
+      std::move(ms.begin(), ms.end(), std::back_inserter(res));
+    }
   }
   return res;
 }
@@ -108,6 +139,52 @@ std::vector<std::shared_ptr<Meter>> Registry::Meters() const noexcept {
     res.emplace_back(pair.second);
   }
   return res;
+}
+
+void Registry::removed_expired_meters() noexcept {
+  std::lock_guard<std::mutex> lock{meters_mutex};
+  auto now = std::chrono::system_clock::now();
+  auto it = meters_.begin();
+  auto expired = 0;
+  auto total = 0;
+  while (it != meters_.end()) {
+    ++total;
+    if (is_meter_expired(now, *it->second, meter_ttl_)) {
+      it = meters_.erase(it);
+      ++expired;
+    } else {
+      ++it;
+    }
+  }
+  logger_->debug("Removed {} expired meters out of {} total", expired, total);
+}
+
+void Registry::expirer() noexcept {
+  if (meter_ttl_.count() == 0) {
+    logger_->debug("Not expiring meters due to meter_ttl = 0");
+    return;
+  }
+
+  auto freq_millis = config_->expiration_frequency;
+  logger_->debug("Starting metrics expiration. Meter ttl={}s running every {}s",
+                 meter_ttl_.count() / 1000, freq_millis.count() / 1000);
+
+  using std::chrono::duration_cast;
+  using std::chrono::milliseconds;
+
+  while (!should_stop_) {
+    auto start = clock::now();
+    removed_expired_meters();
+    auto elapsed = clock::now() - start;
+    auto millis = duration_cast<milliseconds>(elapsed);
+    if (millis < freq_millis) {
+      std::unique_lock<std::mutex> lock{cv_mutex_};
+      auto sleep = freq_millis - elapsed;
+      logger_->debug("Expirer sleeping {}ms",
+                     duration_cast<milliseconds>(sleep).count());
+      cv_.wait_for(lock, sleep);
+    }
+  }
 }
 
 }  // namespace spectator

--- a/spectator/registry.h
+++ b/spectator/registry.h
@@ -51,6 +51,12 @@ class Registry {
   void Stop() noexcept;
 
  private:
+  std::atomic<bool> should_stop_;
+  std::mutex cv_mutex_;
+  std::condition_variable cv_;
+  std::thread expirer_thread_;
+  std::chrono::milliseconds meter_ttl_;
+
   std::unique_ptr<Config> config_;
   logger_ptr logger_;
   mutable std::mutex meters_mutex{};
@@ -78,7 +84,13 @@ class Registry {
     return std::static_pointer_cast<M>(meter_ptr);
   }
 
+  void expirer() noexcept;
+
   Publisher<Registry> publisher_;
+
+ protected:
+  // for testing
+  void removed_expired_meters() noexcept;
 };
 
 }  // namespace spectator

--- a/spectator/strings.h
+++ b/spectator/strings.h
@@ -15,9 +15,10 @@ bool IStartsWith(const std::string& s, const std::string& prefix) noexcept;
 
 /// Remove whitespace from the end of a string
 inline void TrimRight(std::string* s) {
-  s->erase(std::find_if(s->rbegin(), s->rend(), [](int c) {
-    return !std::isspace(c);
-  }).base(), s->end());
+  s->erase(std::find_if(s->rbegin(), s->rend(),
+                        [](int c) { return !std::isspace(c); })
+               .base(),
+           s->end());
 }
 
 std::string PathFromUrl(const std::string& url) noexcept;

--- a/spectator/timer.cc
+++ b/spectator/timer.cc
@@ -30,6 +30,7 @@ std::vector<Measurement> Timer::Measure() const noexcept {
 }
 
 void Timer::Record(std::chrono::nanoseconds amount) noexcept {
+  Update();
   int64_t ns = amount.count();
   if (ns >= 0) {
     count_.fetch_add(1, std::memory_order_relaxed);

--- a/test/config_test.cc
+++ b/test/config_test.cc
@@ -1,5 +1,4 @@
 #include "../spectator/config.h"
-#include "../spectator/registry.h"
 #include <gtest/gtest.h>
 
 TEST(Config, Constructor) {

--- a/test/config_test.cc
+++ b/test/config_test.cc
@@ -7,7 +7,7 @@ TEST(Config, Constructor) {
   static constexpr auto kDefault = 0;
 
   // just make sure that our documented Config constructor works
-  spectator::Config config{common_tags, kDefault,
-                           kDefault,    kDefault,
-                           kDefault,    "http://example.org/api/v1/publish"};
+  spectator::Config config{
+      common_tags, kDefault, kDefault, kDefault,
+      kDefault,    kDefault, kDefault, "http://example.org/api/v1/publish"};
 }

--- a/test/counter_test.cc
+++ b/test/counter_test.cc
@@ -76,4 +76,17 @@ TEST(Counter, Measure) {
   EXPECT_TRUE(c->Measure().empty())
       << "Counters should not report 0 increments";
 }
+
+TEST(Counter, Updated) {
+  auto counter = getCounter("c");
+  counter->Increment();
+
+  auto t1 = counter->Updated();
+  auto t2 = counter->Updated();
+  EXPECT_EQ(t1, t2);
+
+  usleep(1);
+  counter->Increment();
+  EXPECT_TRUE(counter->Updated() > t1);
+}
 }  // namespace

--- a/test/dist_summary_test.cc
+++ b/test/dist_summary_test.cc
@@ -68,4 +68,18 @@ TEST(DistributionSummary, Measure) {
   ds->Record(200);
   expect_dist_summary(*ds, 2, 300, 100 * 100 + 200 * 200, 200);
 }
+
+TEST(DistributionSummary, Updated) {
+  auto ds = getDS();
+  ds->Record(1);
+
+  auto t1 = ds->Updated();
+  auto t2 = ds->Updated();
+  EXPECT_EQ(t1, t2);
+
+  usleep(1);
+  ds->Record(1);
+  EXPECT_TRUE(ds->Updated() > t1);
+}
+
 }  // namespace

--- a/test/gauge_test.cc
+++ b/test/gauge_test.cc
@@ -37,4 +37,18 @@ TEST(Gauge, Measure) {
   // filter NaNs at the source
   EXPECT_TRUE(g->Measure().empty()) << "Gauges should not include NaNs";
 }
+
+TEST(Gauge, Updated) {
+  auto gauge = getGauge("g");
+  gauge->Set(1);
+
+  auto t1 = gauge->Updated();
+  auto t2 = gauge->Updated();
+  EXPECT_EQ(t1, t2);
+
+  usleep(1);
+  gauge->Set(1);
+  EXPECT_TRUE(gauge->Updated() > t1);
+}
+
 }  // namespace

--- a/test/max_gauge_test.cc
+++ b/test/max_gauge_test.cc
@@ -56,4 +56,17 @@ TEST(MaxGauge, Measure) {
   EXPECT_EQ(expected, measures);
 }
 
+TEST(MaxGauge, Updated) {
+  auto m = getMaxGauge("m");
+  m->Update(1);
+
+  auto t1 = m->Updated();
+  auto t2 = m->Updated();
+  EXPECT_EQ(t1, t2);
+
+  usleep(1);
+  m->Set(2);
+  EXPECT_TRUE(m->Updated() > t1);
+}
+
 }  // namespace

--- a/test/monotonic_counter_test.cc
+++ b/test/monotonic_counter_test.cc
@@ -66,4 +66,16 @@ TEST(MonotonicCounter, Measure) {
   EXPECT_TRUE(c->Measure().empty())
       << "MonotonicCounters should not report delta=0";
 }
+
+TEST(MonotonicCounter, Update) {
+  auto counter = getMonotonicCounter("m");
+  counter->Set(1);
+
+  auto t1 = counter->Updated();
+  auto t2 = counter->Updated();
+  EXPECT_EQ(t1, t2);
+  usleep(1);
+  counter->Set(2);
+  EXPECT_TRUE(counter->Updated() > t1);
+}
 }  // namespace

--- a/test/timer_test.cc
+++ b/test/timer_test.cc
@@ -67,4 +67,17 @@ TEST(Timer, Measure) {
   t->Record(std::chrono::nanoseconds(200));
   expect_timer(*t, 2, 300, 100 * 100 + 200 * 200, 200);
 }
+
+TEST(Timer, Updated) {
+  auto timer = getTimer();
+  timer->Record(std::chrono::nanoseconds(1));
+
+  auto t1 = timer->Updated();
+  auto t2 = timer->Updated();
+  EXPECT_EQ(t1, t2);
+
+  usleep(1);
+  timer->Record(std::chrono::nanoseconds(1));
+  EXPECT_TRUE(timer->Updated() > t1);
+}
 }  // namespace


### PR DESCRIPTION
To keep our memory usage under control we need to expire meters that are
inactive. We introduce two configuration settings to help us control
this:

meter_ttl - how long to keep a meter that hasn't received any activity
in our registry

expiration_frequency - how frequently to run the janitorial task of
expiring meters