### PR TITLE
Automatically Stop the registry

### DIFF
--- a/spectator/publisher.h
+++ b/spectator/publisher.h
@@ -46,9 +46,6 @@ class Publisher {
       should_stop_ = true;
       cv_.notify_all();
       sender_thread_.join();
-    } else {
-      registry_->GetLogger()->warn(
-          "Registry was never started. Ignoring stop request");
     }
 
     if (http_initialized_.exchange(false)) {

--- a/spectator/registry.h
+++ b/spectator/registry.h
@@ -18,6 +18,7 @@ class Registry {
   using logger_ptr = std::shared_ptr<spdlog::logger>;
 
   Registry(std::unique_ptr<Config> config, logger_ptr logger) noexcept;
+  ~Registry() noexcept { Stop(); }
   const Config& GetConfig() const noexcept;
   logger_ptr GetLogger() const noexcept;
 


### PR DESCRIPTION
In case the user does not manually call `Stop` we need to join our
expirer thread otherwise we will get an error at shutdown