### PR TITLE
Helper to get the number of meters in the registry

### DIFF
--- a/spectator/registry.h
+++ b/spectator/registry.h
@@ -47,6 +47,7 @@ class Registry {
 
   std::vector<std::shared_ptr<Meter>> Meters() const noexcept;
   std::vector<Measurement> Measurements() const noexcept;
+  std::size_t Size() const noexcept { return meters_.size(); }
 
   void Start() noexcept;
   void Stop() noexcept;

--- a/test/registry_test.cc
+++ b/test/registry_test.cc
@@ -125,4 +125,17 @@ TEST(Registry, Expiration) {
   ASSERT_EQ(r.Meters().size(), 1);
 }
 
+TEST(Registry, Size) {
+  Registry r{GetConfiguration(), DefaultLogger()};
+  EXPECT_EQ(r.Size(), 0);
+
+  r.GetCounter("foo");
+  r.GetTimer("bar");
+  EXPECT_EQ(r.Size(), 2);
+
+  r.GetCounter("foo");
+  r.GetTimer("bar2");
+  EXPECT_EQ(r.Size(), 3);
+}
+
 }  // namespace


### PR DESCRIPTION
Add a simple function to keep track of the number of meters in the
registry. Quite useful for debugging/book keeping.