### PR TITLE
Wait one interval before running expiration tasks

### DIFF
--- a/spectator/registry.cc
+++ b/spectator/registry.cc
@@ -172,6 +172,12 @@ void Registry::expirer() noexcept {
   using std::chrono::duration_cast;
   using std::chrono::milliseconds;
 
+  // do not attempt to expire meters immediately after
+  // Start - wait one freq_millis interval
+  {
+    std::unique_lock<std::mutex> lock{cv_mutex_};
+    cv_.wait_for(lock, freq_millis);
+  }
   while (!should_stop_) {
     auto start = clock::now();
     removed_expired_meters();


### PR DESCRIPTION
Fix a bug where the expiration task would run immediately after the
registry is started and would clean up all the registered meters which
wouldn't have been updated yet