### PR TITLE
Cache Ids used in measurements

### DIFF
--- a/spectator/counter.cc
+++ b/spectator/counter.cc
@@ -10,9 +10,12 @@ IdPtr Counter::MeterId() const noexcept { return id_; }
 std::vector<Measurement> Counter::Measure() const noexcept {
   auto count = count_.exchange(0.0, std::memory_order_relaxed);
   if (count > 0) {
-    return std::vector<Measurement>(
-        {{Id::WithDefaultStat(id_, "count"), count}});
+    if (!count_id_) {
+      count_id_ = Id::WithDefaultStat(id_, "count");
+    }
+    return std::vector<Measurement>({{count_id_, count}});
   }
+
   return std::vector<Measurement>();
 }
 

--- a/spectator/counter.h
+++ b/spectator/counter.h
@@ -18,6 +18,7 @@ class Counter : public Meter {
 
  private:
   IdPtr id_;
+  mutable IdPtr count_id_;
   mutable std::atomic<double> count_;
 };
 

--- a/spectator/dist_summary.cc
+++ b/spectator/dist_summary.cc
@@ -15,14 +15,21 @@ std::vector<Measurement> DistributionSummary::Measure() const noexcept {
     return results;
   }
 
+  if (!count_id_) {
+    total_id_ = id_->WithStat("totalAmount");
+    total_sq_id_ = id_->WithStat("totalOfSquares");
+    max_id_ = id_->WithStat("max");
+    count_id_ = id_->WithStat("count");
+  }
+
   auto total = total_.exchange(0.0, std::memory_order_relaxed);
   auto t_sq = totalSq_.exchange(0.0, std::memory_order_relaxed);
   auto mx = max_.exchange(0.0, std::memory_order_relaxed);
   results.reserve(4);
-  results.push_back({id_->WithStat("count"), static_cast<double>(cnt)});
-  results.push_back({id_->WithStat("totalAmount"), total});
-  results.push_back({id_->WithStat("totalOfSquares"), t_sq});
-  results.push_back({id_->WithStat("max"), mx});
+  results.push_back({count_id_, static_cast<double>(cnt)});
+  results.push_back({total_id_, total});
+  results.push_back({total_sq_id_, t_sq});
+  results.push_back({max_id_, mx});
   return results;
 }
 

--- a/spectator/dist_summary.h
+++ b/spectator/dist_summary.h
@@ -19,6 +19,10 @@ class DistributionSummary : public Meter {
 
  private:
   IdPtr id_;
+  mutable IdPtr count_id_;
+  mutable IdPtr total_id_;
+  mutable IdPtr total_sq_id_;
+  mutable IdPtr max_id_;
   mutable std::atomic<int64_t> count_;
   mutable std::atomic<double> total_;
   mutable std::atomic<double> totalSq_;

--- a/spectator/gauge.cc
+++ b/spectator/gauge.cc
@@ -13,7 +13,10 @@ std::vector<Measurement> Gauge::Measure() const noexcept {
   if (std::isnan(value)) {
     return std::vector<Measurement>();
   }
-  return std::vector<Measurement>({{id_->WithStat("gauge"), value}});
+  if (!gauge_id_) {
+    gauge_id_ = Id::WithDefaultStat(id_, "gauge");
+  }
+  return std::vector<Measurement>({{gauge_id_, value}});
 }
 
 void Gauge::Set(double value) noexcept {

--- a/spectator/gauge.h
+++ b/spectator/gauge.h
@@ -17,6 +17,7 @@ class Gauge : public Meter {
 
  private:
   IdPtr id_;
+  mutable IdPtr gauge_id_;
   mutable std::atomic<double> value_;
 };
 

--- a/spectator/max_gauge.cc
+++ b/spectator/max_gauge.cc
@@ -15,7 +15,10 @@ std::vector<Measurement> MaxGauge::Measure() const noexcept {
   if (value == kMinValue) {
     return std::vector<Measurement>();
   }
-  return std::vector<Measurement>({{id_->WithStat("max"), value}});
+  if (!max_id_) {
+    max_id_ = id_->WithStat("max");
+  }
+  return std::vector<Measurement>({{max_id_, value}});
 }
 
 double MaxGauge::Get() const noexcept {

--- a/spectator/max_gauge.h
+++ b/spectator/max_gauge.h
@@ -20,6 +20,7 @@ class MaxGauge : public Meter {
 
  private:
   IdPtr id_;
+  mutable IdPtr max_id_;
   mutable std::atomic<double> value_;
 };
 

--- a/spectator/monotonic_counter.cc
+++ b/spectator/monotonic_counter.cc
@@ -24,7 +24,10 @@ std::vector<Measurement> MonotonicCounter::Measure() const noexcept {
   prev_value_.store(value_.load(std::memory_order_relaxed),
                     std::memory_order_relaxed);
   if (delta > 0) {
-    return std::vector<Measurement>({{id_->WithStat("count"), delta}});
+    if (!count_id_) {
+      count_id_ = id_->WithStat("count");
+    }
+    return std::vector<Measurement>({{count_id_, delta}});
   }
   return std::vector<Measurement>{};
 }

--- a/spectator/monotonic_counter.h
+++ b/spectator/monotonic_counter.h
@@ -18,6 +18,7 @@ class MonotonicCounter : public Meter {
 
  private:
   IdPtr id_;
+  mutable IdPtr count_id_;
   mutable std::atomic<double> value_;
   mutable std::atomic<double> prev_value_;
 };

--- a/spectator/timer.cc
+++ b/spectator/timer.cc
@@ -15,6 +15,13 @@ std::vector<Measurement> Timer::Measure() const noexcept {
     return results;
   }
 
+  if (!count_id_) {
+    total_id_ = id_->WithStat("totalTime");
+    total_sq_id_ = id_->WithStat("totalOfSquares");
+    max_id_ = id_->WithStat("max");
+    count_id_ = id_->WithStat("count");
+  }
+
   auto total = total_.exchange(0, std::memory_order_relaxed);
   auto total_secs = total / 1e9;
   auto t_sq = totalSq_.exchange(0.0, std::memory_order_relaxed);
@@ -22,10 +29,10 @@ std::vector<Measurement> Timer::Measure() const noexcept {
   auto mx = max_.exchange(0, std::memory_order_relaxed);
   auto mx_secs = mx / 1e9;
   results.reserve(4);
-  results.push_back({id_->WithStat("count"), static_cast<double>(cnt)});
-  results.push_back({id_->WithStat("totalTime"), total_secs});
-  results.push_back({id_->WithStat("totalOfSquares"), t_sq_secs});
-  results.push_back({id_->WithStat("max"), mx_secs});
+  results.push_back({count_id_, static_cast<double>(cnt)});
+  results.push_back({total_id_, total_secs});
+  results.push_back({total_sq_id_, t_sq_secs});
+  results.push_back({max_id_, mx_secs});
   return results;
 }
 

--- a/spectator/timer.h
+++ b/spectator/timer.h
@@ -18,6 +18,10 @@ class Timer : public Meter {
 
  private:
   IdPtr id_;
+  mutable IdPtr count_id_;
+  mutable IdPtr total_id_;
+  mutable IdPtr total_sq_id_;
+  mutable IdPtr max_id_;
   mutable std::atomic<int64_t> count_;
   mutable std::atomic<int64_t> total_;
   mutable std::atomic<double> totalSq_;


### PR DESCRIPTION
Avoid creating new Ids every time `Measure` is called. This gives us a
nice performance improvement especially when measuring timers and dist
summaries.