### PR TITLE
Make registry.Size thread safe

### DIFF
--- a/spectator/registry.h
+++ b/spectator/registry.h
@@ -47,7 +47,10 @@ class Registry {
 
   std::vector<std::shared_ptr<Meter>> Meters() const noexcept;
   std::vector<Measurement> Measurements() const noexcept;
-  std::size_t Size() const noexcept { return meters_.size(); }
+  std::size_t Size() const noexcept { 
+    std::lock_guard<std::mutex> lock(meters_mutex);
+    return meters_.size(); 
+  }
 
   void Start() noexcept;
   void Stop() noexcept;


### PR DESCRIPTION
Not sure about the impact of not being thread safe here but since this
method is not supposed to be called frequently, better be safe and
correct.