### PR TITLE
Avoid common_tags lookup in append_measurements

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -90,7 +90,6 @@ cc_test(
     deps = [
         ":spectator",
         "@com_google_benchmark//:benchmark",
-        "@com_github_tessil_hopscotch_map//:hopscotch_map",
       ]
     )
 
@@ -100,6 +99,14 @@ cc_test(
     deps = [
         ":spectator",
         "@com_google_benchmark//:benchmark",
-        "@com_github_tessil_hopscotch_map//:hopscotch_map",
+      ]
+    )
+
+cc_test(
+    name = "append_measurements",
+    srcs = ["bench/append_measurements.cc",],
+    deps = [
+        ":spectator",
+        "@com_google_benchmark//:benchmark",
       ]
     )

--- a/bench/README.md
+++ b/bench/README.md
@@ -127,3 +127,17 @@ BM_HopscotchMapWithTag           1971 ns         1970 ns       359683
 BM_HopscotchMapHashWithTag       1313 ns         1312 ns       540011
 ================================================================================
 ```
+
+## Benchmarking the effect of doing/avoiding common tag -> string table ids
+
+```
+bazel test -c opt append_measurements
+
+clang-10 on bionic
+
+--------------------------------------------------------------------
+Benchmark                          Time             CPU   Iterations
+--------------------------------------------------------------------
+BM_append_common_tags           1163 ns         1163 ns       561106
+BM_append_common_tags_ids        706 ns          706 ns      1214936
+```

--- a/bench/append_measurements.cc
+++ b/bench/append_measurements.cc
@@ -1,0 +1,121 @@
+// Benchmarks publisher#append_measurements
+
+#include <benchmark/benchmark.h>
+#include "spectator/publisher.h"
+#include <memory>
+
+using spectator::Measurement;
+
+using StrTable = ska::flat_hash_map<std::string, int>;
+static StrTable get_string_table() {
+  StrTable string_table;
+  for (auto i = 0; i < 1000; ++i) {
+    string_table[fmt::format("some.prefix.{:04}", i)] = i;
+  }
+  return string_table;
+}
+
+static std::map<std::string, std::string> get_common_tags() {
+  static constexpr auto kNumTags = 7;  // assume 7 common tags
+
+  std::map<std::string, std::string> tags;
+  for (auto i = 0; i < kNumTags; ++i) {
+    auto key = fmt::format("some.prefix.{:04}", 2 * i);
+    auto value = fmt::format("some.prefix.{:04}", 2 * i + 1);
+    tags[key] = value;
+  }
+  return tags;
+}
+
+static std::vector<int> get_common_tags_ids() {
+  static constexpr auto kNumTags = 7;
+  std::vector<int> ids;
+  ids.reserve(kNumTags * 2);
+  for (auto i = 0; i < kNumTags; ++i) {
+    ids.push_back(i);
+  }
+  return ids;
+}
+
+template <typename T>
+void add_tags(rapidjson::Document* payload, const StrTable& strings,
+              const T& tags) {
+  using rapidjson::Value;
+  auto& alloc = payload->GetAllocator();
+  for (const auto& tag : tags) {
+    auto k_pair = strings.find(tag.first);
+    auto v_pair = strings.find(tag.second);
+    assert(k_pair != strings.end());
+    assert(v_pair != strings.end());
+    payload->PushBack(k_pair->second, alloc);
+    payload->PushBack(v_pair->second, alloc);
+  }
+}
+
+void append_measurement_lookup(
+    rapidjson::Document* payload, const StrTable& strings,
+    const std::map<std::string, std::string>& common_tags,
+    const Measurement& m) {
+  auto& alloc = payload->GetAllocator();
+  int64_t total_tags = m.id->GetTags().size() + 1 + common_tags.size();
+  payload->PushBack(total_tags, alloc);
+  add_tags(payload, strings, common_tags);
+  add_tags(payload, strings, m.id->GetTags());
+  auto name_idx = strings.find("name")->second;
+  auto name_value_idx = strings.find(m.id->Name())->second;
+  payload->PushBack(name_idx, alloc);
+  payload->PushBack(name_value_idx, alloc);
+  payload->PushBack(m.value, alloc);
+}
+
+void append_measurement_ids(rapidjson::Document* payload,
+                            const StrTable& strings,
+                            const std::vector<int> common_tags_ids,
+                            const Measurement& m) {
+  auto& alloc = payload->GetAllocator();
+  int64_t total_tags = m.id->GetTags().size() + 1 + common_tags_ids.size() / 2;
+  payload->PushBack(total_tags, alloc);
+  for (auto i : common_tags_ids) {
+    payload->PushBack(i, alloc);
+  }
+  add_tags(payload, strings, m.id->GetTags());
+  auto name_idx = strings.find("name")->second;
+  auto name_value_idx = strings.find(m.id->Name())->second;
+  payload->PushBack(name_idx, alloc);
+  payload->PushBack(name_value_idx, alloc);
+  payload->PushBack(m.value, alloc);
+}
+
+static spectator::IdPtr get_id() {
+  auto tags = spectator::Tags{{{"some.prefix.0100", "some.prefix.0101"},
+                               {"some.prefix.0102", "some.prefix.0103"},
+                               {"some.prefix.0104", "some.prefix.0105"}}};
+  return std::make_shared<spectator::Id>(std::string{"some.prefix.0123"}, tags);
+}
+
+static void BM_append_common_tags(benchmark::State& state) {
+  // test the behavior where we have to lookup the common tags in
+  // append_measurements
+  rapidjson::Document payload{rapidjson::kArrayType};
+  auto strings = get_string_table();
+  auto common_tags = get_common_tags();
+  Measurement m{get_id(), 100.0};
+  for (auto _ : state) {
+    append_measurement_lookup(&payload, strings, common_tags, m);
+  }
+}
+static void BM_append_common_tags_ids(benchmark::State& state) {
+  // test the behavior where we have to lookup the common tags in
+  // append_measurements
+  rapidjson::Document payload{rapidjson::kArrayType};
+  auto strings = get_string_table();
+  auto ids = get_common_tags_ids();
+  Measurement m{get_id(), 100.0};
+  for (auto _ : state) {
+    append_measurement_ids(&payload, strings, ids, m);
+  }
+}
+
+BENCHMARK(BM_append_common_tags);
+BENCHMARK(BM_append_common_tags_ids);
+BENCHMARK_MAIN();


### PR DESCRIPTION
While profiling a program that generated over 100k
measurements, I noticed that `append_measurements` was using quite a bit
of cpu, and a big portion of it was mapping the common tags to their
string table id when constructing the payload.

A simple benchmark shows that avoiding that lookup can provide a big
benefit:

```
--------------------------------------------------------------------
Benchmark                          Time             CPU   Iterations
--------------------------------------------------------------------
BM_append_common_tags            935 ns          934 ns       635803
BM_append_common_tags_ids        509 ns          508 ns      1000000
```