### PR TITLE
Keep track of invalid measurements

### DIFF
--- a/test/registry_test.cc
+++ b/test/registry_test.cc
@@ -1,4 +1,5 @@
 #include "../spectator/registry.h"
+#include "test_utils.h"
 #include <fmt/ostream.h>
 #include <gtest/gtest.h>
 
@@ -79,7 +80,7 @@ TEST(Registry, Meters) {
   auto t = r.GetTimer("t");
   auto c = r.GetCounter("c");
   r.GetTimer("t")->Count();
-  auto meters = r.Meters();
+  auto meters = my_meters(r);
   ASSERT_EQ(meters.size(), 2);
 }
 
@@ -116,26 +117,27 @@ TEST(Registry, Expiration) {
   auto d = r.GetDistributionSummary("d");
   auto t = r.GetTimer("t");
   auto m = r.GetMaxGauge("m");
-  ASSERT_EQ(r.Meters().size(), 5);
+  ASSERT_EQ(my_meters(r).size(), 5);
 
   usleep(2000);  // 2ms
   c->Increment();
   r.expire();
 
-  ASSERT_EQ(r.Meters().size(), 1);
+  ASSERT_EQ(my_meters(r).size(), 1);
 }
 
 TEST(Registry, Size) {
   Registry r{GetConfiguration(), DefaultLogger()};
-  EXPECT_EQ(r.Size(), 0);
+  auto base_number = r.Meters().size();
+  EXPECT_EQ(r.Size(), base_number);
 
   r.GetCounter("foo");
   r.GetTimer("bar");
-  EXPECT_EQ(r.Size(), 2);
+  EXPECT_EQ(r.Size(), 2 + base_number);
 
   r.GetCounter("foo");
   r.GetTimer("bar2");
-  EXPECT_EQ(r.Size(), 3);
+  EXPECT_EQ(r.Size(), 3 + base_number);
 }
 
 }  // namespace

--- a/test/test_utils.h
+++ b/test/test_utils.h
@@ -1,9 +1,22 @@
 #pragma once
 
-#include "../spectator/measurement.h"
+#include "../spectator/registry.h"
 #include <map>
 #include <string>
 #include <vector>
 
 std::map<std::string, double> measurements_to_map(
     const std::vector<spectator::Measurement>& measurements);
+
+using MeterPtr = std::shared_ptr<spectator::Meter>;
+inline std::vector<MeterPtr> my_meters(const spectator::Registry& registry) {
+  std::vector<MeterPtr> result;
+  auto meters = registry.Meters();
+  std::copy_if(meters.begin(), meters.end(), std::back_inserter(result),
+               [](const MeterPtr& m) {
+                 auto found =
+                     m->MeterId()->Name().rfind("spectator.measurements", 0);
+                 return found == std::string::npos;
+               });
+  return result;
+}


### PR DESCRIPTION
Show the unique warnings we get from the server when we post
measurements. Additionally standardize on the Ids used by spectator-js:

`spectator.measurements id=sent|dropped
error=validation|http-error|other`

for the counters that track the number of measurements sent successfully
versus the ones that were dropped for various reasons.