### PR TITLE
Minor update to benchmark for tables

### DIFF
--- a/bench/bench_tables.cc
+++ b/bench/bench_tables.cc
@@ -27,8 +27,9 @@ static std::shared_ptr<Counter> get_counter(int i) {
 }
 
 template <typename T>
-void TestTable(benchmark::State& state) {
+void BenchTable(benchmark::State& state) {
   T table;
+  srand(1);
   for (auto _ : state) {
     auto counter = get_counter(state.range(0));
     benchmark::DoNotOptimize(table.insert({counter->MeterId(), counter}));
@@ -36,35 +37,14 @@ void TestTable(benchmark::State& state) {
 }
 
 using meter_ptr = std::shared_ptr<Meter>;
-static void BM_FlatHashMap(benchmark::State& state) {
-  srand(1);
-  TestTable<ska::flat_hash_map<IdPtr, meter_ptr>>(state);
-}
-
-static void BM_UnorderedMap(benchmark::State& state) {
-  srand(1);
-  TestTable<std::unordered_map<IdPtr, meter_ptr>>(state);
-}
-
-static void BM_HopscotchMap(benchmark::State& state) {
-  srand(1);
-  using table_t = tsl::hopscotch_map<IdPtr, meter_ptr>;
-  TestTable<table_t>(state);
-}
-
-static void BM_HopscotchMapHash(benchmark::State& state) {
-  srand(1);
-  // test storing the hash as part of the entry
-  using table_t =
-      tsl::hopscotch_map<IdPtr, meter_ptr, std::hash<IdPtr>,
-                         std::equal_to<IdPtr>,
-                         std::allocator<std::pair<IdPtr, meter_ptr>>, 30, true>;
-  TestTable<table_t>(state);
-}
-
-BENCHMARK(BM_FlatHashMap)->RangeMultiplier(256)->Range(8, 8 << 20);
-BENCHMARK(BM_UnorderedMap)->RangeMultiplier(256)->Range(8, 8 << 20);
-BENCHMARK(BM_HopscotchMap)->RangeMultiplier(256)->Range(8, 8 << 20);
-BENCHMARK(BM_HopscotchMapHash)->RangeMultiplier(256)->Range(8, 8 << 20);
+using flat=ska::flat_hash_map<IdPtr, meter_ptr>;
+using unordered=std::unordered_map<IdPtr, meter_ptr>;
+using hop=tsl::hopscotch_map<IdPtr, meter_ptr>;
+using hophash=tsl::hopscotch_map<IdPtr, meter_ptr, std::hash<IdPtr>,
+    std::equal_to<IdPtr>, std::allocator<std::pair<IdPtr, meter_ptr>>, 30, true>;
+BENCHMARK_TEMPLATE(BenchTable, unordered)->RangeMultiplier(256)->Range(8, 8 << 20);
+BENCHMARK_TEMPLATE(BenchTable, flat)->RangeMultiplier(256)->Range(8, 8 << 20);
+BENCHMARK_TEMPLATE(BenchTable, hop)->RangeMultiplier(256)->Range(8, 8 << 20);
+BENCHMARK_TEMPLATE(BenchTable, hophash)->RangeMultiplier(256)->Range(8, 8 << 20);
 
 BENCHMARK_MAIN();


### PR DESCRIPTION
Use the `BENCHMARK_TEMPLATE` macro instead of using our own template
function