### PR TITLE
Registry name/tags convenience overloads

### DIFF
--- a/spectator/registry.cc
+++ b/spectator/registry.cc
@@ -24,8 +24,9 @@ std::shared_ptr<Counter> Registry::GetCounter(IdPtr id) noexcept {
   return create_and_register_as_needed<Counter>(std::move(id));
 }
 
-std::shared_ptr<Counter> Registry::GetCounter(std::string name) noexcept {
-  return GetCounter(CreateId(std::move(name), Tags{}));
+std::shared_ptr<Counter> Registry::GetCounter(std::string name,
+                                              Tags tags) noexcept {
+  return GetCounter(CreateId(std::move(name), std::move(tags)));
 }
 
 std::shared_ptr<DistributionSummary> Registry::GetDistributionSummary(
@@ -34,24 +35,26 @@ std::shared_ptr<DistributionSummary> Registry::GetDistributionSummary(
 }
 
 std::shared_ptr<DistributionSummary> Registry::GetDistributionSummary(
-    std::string name) noexcept {
-  return GetDistributionSummary(CreateId(std::move(name), Tags{}));
+    std::string name, Tags tags) noexcept {
+  return GetDistributionSummary(CreateId(std::move(name), std::move(tags)));
 }
 
 std::shared_ptr<Gauge> Registry::GetGauge(IdPtr id) noexcept {
   return create_and_register_as_needed<Gauge>(std::move(id));
 }
 
-std::shared_ptr<Gauge> Registry::GetGauge(std::string name) noexcept {
-  return GetGauge(CreateId(std::move(name), Tags{}));
+std::shared_ptr<Gauge> Registry::GetGauge(std::string name,
+                                          Tags tags) noexcept {
+  return GetGauge(CreateId(std::move(name), std::move(tags)));
 }
 
 std::shared_ptr<MaxGauge> Registry::GetMaxGauge(IdPtr id) noexcept {
   return create_and_register_as_needed<MaxGauge>(std::move(id));
 }
 
-std::shared_ptr<MaxGauge> Registry::GetMaxGauge(std::string name) noexcept {
-  return GetMaxGauge(CreateId(std::move(name), Tags{}));
+std::shared_ptr<MaxGauge> Registry::GetMaxGauge(std::string name,
+                                                Tags tags) noexcept {
+  return GetMaxGauge(CreateId(std::move(name), std::move(tags)));
 }
 
 std::shared_ptr<MonotonicCounter> Registry::GetMonotonicCounter(
@@ -60,16 +63,17 @@ std::shared_ptr<MonotonicCounter> Registry::GetMonotonicCounter(
 }
 
 std::shared_ptr<MonotonicCounter> Registry::GetMonotonicCounter(
-    std::string name) noexcept {
-  return GetMonotonicCounter(CreateId(std::move(name), Tags{}));
+    std::string name, Tags tags) noexcept {
+  return GetMonotonicCounter(CreateId(std::move(name), std::move(tags)));
 }
 
 std::shared_ptr<Timer> Registry::GetTimer(IdPtr id) noexcept {
   return create_and_register_as_needed<Timer>(std::move(id));
 }
 
-std::shared_ptr<Timer> Registry::GetTimer(std::string name) noexcept {
-  return GetTimer(CreateId(std::move(name), Tags{}));
+std::shared_ptr<Timer> Registry::GetTimer(std::string name,
+                                          Tags tags) noexcept {
+  return GetTimer(CreateId(std::move(name), std::move(tags)));
 }
 
 // only insert if it doesn't exist, otherwise return the existing meter

--- a/spectator/registry.h
+++ b/spectator/registry.h
@@ -22,34 +22,36 @@ class Registry {
   const Config& GetConfig() const noexcept;
   logger_ptr GetLogger() const noexcept;
 
-  IdPtr CreateId(std::string name, Tags tags) const noexcept;
+  static IdPtr CreateId(std::string name, Tags tags) const noexcept;
 
   std::shared_ptr<Counter> GetCounter(IdPtr id) noexcept;
-  std::shared_ptr<Counter> GetCounter(std::string name) noexcept;
+  std::shared_ptr<Counter> GetCounter(std::string name,
+                                      Tags tags = {}) noexcept;
 
   std::shared_ptr<MonotonicCounter> GetMonotonicCounter(IdPtr id) noexcept;
   std::shared_ptr<MonotonicCounter> GetMonotonicCounter(
-      std::string name) noexcept;
+      std::string name, Tags tags = {}) noexcept;
 
   std::shared_ptr<DistributionSummary> GetDistributionSummary(
       IdPtr id) noexcept;
   std::shared_ptr<DistributionSummary> GetDistributionSummary(
-      std::string name) noexcept;
+      std::string name, Tags tags = {}) noexcept;
 
   std::shared_ptr<Gauge> GetGauge(IdPtr id) noexcept;
-  std::shared_ptr<Gauge> GetGauge(std::string name) noexcept;
+  std::shared_ptr<Gauge> GetGauge(std::string name, Tags tags = {}) noexcept;
 
   std::shared_ptr<MaxGauge> GetMaxGauge(IdPtr id) noexcept;
-  std::shared_ptr<MaxGauge> GetMaxGauge(std::string name) noexcept;
+  std::shared_ptr<MaxGauge> GetMaxGauge(std::string name,
+                                        Tags tags = {}) noexcept;
 
   std::shared_ptr<Timer> GetTimer(IdPtr id) noexcept;
-  std::shared_ptr<Timer> GetTimer(std::string name) noexcept;
+  std::shared_ptr<Timer> GetTimer(std::string name, Tags tags = {}) noexcept;
 
   std::vector<std::shared_ptr<Meter>> Meters() const noexcept;
   std::vector<Measurement> Measurements() const noexcept;
-  std::size_t Size() const noexcept { 
+  std::size_t Size() const noexcept {
     std::lock_guard<std::mutex> lock(meters_mutex);
-    return meters_.size(); 
+    return meters_.size();
   }
 
   void Start() noexcept;

--- a/spectator/registry.h
+++ b/spectator/registry.h
@@ -22,7 +22,7 @@ class Registry {
   const Config& GetConfig() const noexcept;
   logger_ptr GetLogger() const noexcept;
 
-  static IdPtr CreateId(std::string name, Tags tags) const noexcept;
+  IdPtr CreateId(std::string name, Tags tags) const noexcept;
 
   std::shared_ptr<Counter> GetCounter(IdPtr id) noexcept;
   std::shared_ptr<Counter> GetCounter(std::string name,

--- a/test/registry_test.cc
+++ b/test/registry_test.cc
@@ -7,6 +7,7 @@ namespace {
 using spectator::DefaultLogger;
 using spectator::GetConfiguration;
 using spectator::Registry;
+using spectator::Tags;
 
 TEST(Registry, Counter) {
   Registry r{GetConfiguration(), DefaultLogger()};
@@ -32,31 +33,45 @@ TEST(Registry, DistSummary) {
 TEST(Registry, Gauge) {
   Registry r{GetConfiguration(), DefaultLogger()};
   auto g = r.GetGauge("g");
+  auto g2 = r.GetGauge("g", Tags{{"id", "2"}});
   g->Set(100);
+  g2->Set(101);
   EXPECT_DOUBLE_EQ(r.GetGauge("g")->Get(), 100);
+  EXPECT_DOUBLE_EQ(r.GetGauge("g", Tags{{"id", "2"}})->Get(), 101);
 }
 
 TEST(Registry, MaxGauge) {
   Registry r{GetConfiguration(), DefaultLogger()};
   auto g = r.GetMaxGauge("g");
+  auto g2 = r.GetMaxGauge("g", Tags{{"id", "2"}});
   g->Update(100);
+  g2->Set(101);
   EXPECT_DOUBLE_EQ(r.GetMaxGauge("g")->Get(), 100);
+  EXPECT_DOUBLE_EQ(r.GetMaxGauge("g", Tags{{"id", "2"}})->Get(), 101);
 }
 
 TEST(Registry, MonotonicCounter) {
   Registry r{GetConfiguration(), DefaultLogger()};
   auto c = r.GetMonotonicCounter("m");
+  auto c2 = r.GetMonotonicCounter("m", Tags{{"id", "2"}});
   c->Set(100);
   c->Measure();
   c->Set(200);
+  c2->Set(100);
+  c2->Measure();
+  c2->Set(201);
   EXPECT_DOUBLE_EQ(r.GetMonotonicCounter("m")->Delta(), 100);
+  EXPECT_DOUBLE_EQ(r.GetMonotonicCounter("m", Tags{{"id", "2"}})->Delta(), 101);
 }
 
 TEST(Registry, Timer) {
   Registry r{GetConfiguration(), DefaultLogger()};
   auto t = r.GetTimer("t");
+  auto t2 = r.GetTimer("t", Tags{{"id", "2"}});
   t->Record(std::chrono::microseconds(1));
+  t2->Record(std::chrono::microseconds(2));
   EXPECT_EQ(r.GetTimer("t")->TotalTime(), 1000);
+  EXPECT_EQ(r.GetTimer("t", Tags{{"id", "2"}})->TotalTime(), 2000);
 }
 
 TEST(Registry, WrongType) {


### PR DESCRIPTION
Add the ability to get meters specifying a name and tags to the registry
instead of having to explicitly create an id whenever we need to pass
some tags