### PR TITLE
Do not copy the shared_ptr in insert_if_needed

### DIFF
--- a/spectator/publisher.h
+++ b/spectator/publisher.h
@@ -297,8 +297,6 @@ class Publisher {
             auto err_count = body["errorCount"].GetInt();
             num_err += err_count;
             num_sent += to_advance - err_count;
-            logger->debug("Err: {} - Sent: {} / {} - {}", err_count,
-                          to_advance - err_count, num_err, num_sent);
             invalidMetrics_->Add(err_count);
             sentMetrics_->Add(to_advance - err_count);
             auto messages = body["message"].GetArray();
@@ -319,6 +317,12 @@ class Publisher {
         num_err += to_advance;
       }
       from = to;
+    }
+    if (num_err > 0) {
+      logger->info("Sent {}/{} - Validation failures: {}", num_sent,
+                   measurements.size(), num_err);
+    } else {
+      logger->debug("Sent {} measurements with no errors", measurements.size());
     }
     for (const auto& m : err_messages) {
       logger->info("Validation error: {}", m);

--- a/spectator/registry.cc
+++ b/spectator/registry.cc
@@ -80,7 +80,7 @@ std::shared_ptr<Timer> Registry::GetTimer(std::string name,
 std::shared_ptr<Meter> Registry::insert_if_needed(
     std::shared_ptr<Meter> meter) noexcept {
   std::lock_guard<std::mutex> lock(meters_mutex);
-  auto insert_result = meters_.emplace(meter->MeterId(), meter);
+  auto insert_result = meters_.emplace(meter->MeterId(), std::move(meter));
   auto ret = insert_result.first->second;
   return ret;
 }


### PR DESCRIPTION
Noticed we were incrementing/decrementing the reference count of the
shared_ptr unnecessarily when inserting into the map.

Plus improve the logging around invalid measurements returned by the
aggregators