### PR TITLE
Only reset gauge values after expiration

### DIFF
--- a/spectator/gauge.cc
+++ b/spectator/gauge.cc
@@ -7,9 +7,22 @@ static constexpr auto kNAN = std::numeric_limits<double>::quiet_NaN();
 
 Gauge::Gauge(IdPtr id) noexcept : id_{std::move(id)}, value_{kNAN} {}
 
+using std::chrono::system_clock;
+inline bool has_expired(system_clock::time_point updated) {
+  static constexpr auto kTtl = std::chrono::minutes{15};
+  auto ago = system_clock::now() - updated;
+  return ago > kTtl;
+}
+
 IdPtr Gauge::MeterId() const noexcept { return id_; }
 std::vector<Measurement> Gauge::Measure() const noexcept {
-  auto value = value_.exchange(kNAN, std::memory_order_relaxed);
+  double value;
+  if (has_expired(Updated())) {
+    value = value_.exchange(kNAN, std::memory_order_relaxed);
+  } else {
+    value = value_.load(std::memory_order_relaxed);
+  }
+
   if (std::isnan(value)) {
     return std::vector<Measurement>();
   }

--- a/test/gauge_test.cc
+++ b/test/gauge_test.cc
@@ -33,9 +33,7 @@ TEST(Gauge, Measure) {
 
   auto v = g->Get();
   // reset behavior
-  EXPECT_TRUE(std::isnan(v)) << "Gauges should reset after being measured";
-  // filter NaNs at the source
-  EXPECT_TRUE(g->Measure().empty()) << "Gauges should not include NaNs";
+  EXPECT_FALSE(std::isnan(v)) << "Gauges should only reset after expiration";
 }
 
 TEST(Gauge, Updated) {


### PR DESCRIPTION
To be consistent with the behavior of other spectator clients we now
keep the gauge value for up to 15 minutes after it being set.