### PR TITLE
Add Measurements callback mechanism to Registry

### DIFF
--- a/spectator/registry.cc
+++ b/spectator/registry.cc
@@ -133,6 +133,9 @@ std::vector<Measurement> Registry::Measurements() const noexcept {
       std::move(ms.begin(), ms.end(), std::back_inserter(res));
     }
   }
+  for (const auto& callback : ms_callbacks_) {
+    callback(res);
+  }
   return res;
 }
 
@@ -195,6 +198,9 @@ void Registry::expirer() noexcept {
       cv_.wait_for(lock, sleep);
     }
   }
+}
+void Registry::OnMeasurements(Registry::measurements_callback fn) noexcept {
+  ms_callbacks_.emplace_back(std::move(fn));
 }
 
 }  // namespace spectator

--- a/spectator/registry.h
+++ b/spectator/registry.h
@@ -16,11 +16,15 @@ class Registry {
  public:
   using clock = std::chrono::steady_clock;
   using logger_ptr = std::shared_ptr<spdlog::logger>;
+  using measurements_callback =
+      std::function<void(const std::vector<Measurement>&)>;
 
   Registry(std::unique_ptr<Config> config, logger_ptr logger) noexcept;
   ~Registry() noexcept { Stop(); }
   const Config& GetConfig() const noexcept;
   logger_ptr GetLogger() const noexcept;
+
+  void OnMeasurements(measurements_callback fn) noexcept;
 
   IdPtr CreateId(std::string name, Tags tags) const noexcept;
 
@@ -71,6 +75,7 @@ class Registry {
       IdPtr, std::shared_ptr<Meter>, std::hash<IdPtr>, std::equal_to<IdPtr>,
       std::allocator<std::pair<IdPtr, std::shared_ptr<Meter>>>, 30, true>;
   table_t meters_;
+  std::vector<measurements_callback> ms_callbacks_{};
 
   std::shared_ptr<Meter> insert_if_needed(
       std::shared_ptr<Meter> meter) noexcept;

--- a/test/registry_test.cc
+++ b/test/registry_test.cc
@@ -155,4 +155,22 @@ TEST(Registry, Size) {
   EXPECT_EQ(r.Size(), 3 + base_number);
 }
 
+TEST(Registry, OnMeasurements) {
+  Registry r{GetConfiguration(), DefaultLogger()};
+  auto called = false;
+  auto found = false;
+  auto cb = [&](const std::vector<spectator::Measurement>& ms) {
+    called = true;
+    auto id =
+        r.CreateId("some.counter", spectator::Tags{{"statistic", "count"}});
+    auto expected = spectator::Measurement{std::move(id), 1.0};
+    auto it = std::find(ms.begin(), ms.end(), expected);
+    found = it != ms.end();
+  };
+  r.OnMeasurements(cb);
+  r.GetCounter("some.counter")->Increment();
+  r.Measurements();
+  ASSERT_TRUE(called);
+  ASSERT_TRUE(found);
+}
 }  // namespace


### PR DESCRIPTION
This can be used for debugging issues with metrics where the values are
not expected. A calling program can dump the values into a file or log
them as needed.