### PR TITLE
Add spectator.registrySize

### DIFF
--- a/spectator/registry.cc
+++ b/spectator/registry.cc
@@ -10,6 +10,7 @@ Registry::Registry(std::unique_ptr<Config> config,
       meter_ttl_{config->meter_ttl},
       config_{std::move(config)},
       logger_{std::move(logger)},
+      registry_size_{GetDistributionSummary("spectator.registrySize")},
       publisher_(this) {}
 
 const Config& Registry::GetConfig() const noexcept { return *config_; }
@@ -133,6 +134,7 @@ std::vector<Measurement> Registry::Measurements() const noexcept {
       std::move(ms.begin(), ms.end(), std::back_inserter(res));
     }
   }
+  registry_size_->Record(res.size());
   for (const auto& callback : ms_callbacks_) {
     callback(res);
   }

--- a/spectator/registry.h
+++ b/spectator/registry.h
@@ -76,6 +76,7 @@ class Registry {
       std::allocator<std::pair<IdPtr, std::shared_ptr<Meter>>>, 30, true>;
   table_t meters_;
   std::vector<measurements_callback> ms_callbacks_{};
+  std::shared_ptr<DistributionSummary> registry_size_;
 
   std::shared_ptr<Meter> insert_if_needed(
       std::shared_ptr<Meter> meter) noexcept;

--- a/test/registry_test.cc
+++ b/test/registry_test.cc
@@ -173,4 +173,15 @@ TEST(Registry, OnMeasurements) {
   ASSERT_TRUE(called);
   ASSERT_TRUE(found);
 }
+
+TEST(Registry, DistSummary_Size) {
+  Registry r{GetConfiguration(), DefaultLogger()};
+  r.GetTimer("foo")->Record(std::chrono::seconds{42});
+  r.GetCounter("bar")->Increment();
+  // we have 4 measurements from the timer + 1 from the counter
+  r.Measurements();
+  EXPECT_DOUBLE_EQ(
+      r.GetDistributionSummary("spectator.registrySize")->TotalAmount(), 5.0);
+}
+
 }  // namespace

--- a/test/test_utils.h
+++ b/test/test_utils.h
@@ -14,8 +14,7 @@ inline std::vector<MeterPtr> my_meters(const spectator::Registry& registry) {
   auto meters = registry.Meters();
   std::copy_if(meters.begin(), meters.end(), std::back_inserter(result),
                [](const MeterPtr& m) {
-                 auto found =
-                     m->MeterId()->Name().rfind("spectator.measurements", 0);
+                 auto found = m->MeterId()->Name().rfind("spectator.", 0);
                  return found == std::string::npos;
                });
   return result;


### PR DESCRIPTION
This mimics the behavior of the spectator AtlasRegistry. We update a
distribution summary `spectator.registrySize` to track number of
measurements produced by the registry.