### PR TITLE
Make the http client retry 50x

### DIFF
--- a/spectator/http_client.cc
+++ b/spectator/http_client.cc
@@ -183,7 +183,7 @@ HttpResponse HttpClient::method_header(
 }
 
 inline bool is_retryable_error(int http_code) {
-  return http_code == 429 || http_code == 503;
+  return http_code == 429 || (http_code / 100) == 5;
 }
 
 HttpResponse HttpClient::perform(const char* method, const std::string& url,


### PR DESCRIPTION
Sometimes we see some 502s which are safe to be retried when POSTing
measurements to our backends.