### PR TITLE
Reconnect on errors

### DIFF
--- a/spectator/publisher.cc
+++ b/spectator/publisher.cc
@@ -42,9 +42,9 @@ void SpectatordPublisher::local_reconnect(std::string_view path) {
 
 void SpectatordPublisher::setup_unix_domain(std::string_view path) {
   local_reconnect(path);
-  sender_ = [path, this](std::string_view msg) {
-    // get a copy of the file path
-    std::string local_path{path};
+  // get a copy of the file path
+  std::string local_path{path};
+  sender_ = [local_path, this](std::string_view msg) {
     for (auto i = 0; i < 3; ++i) {
       try {
         local_socket_.send(asio::buffer(msg));

--- a/spectator/publisher.h
+++ b/spectator/publisher.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include "config.h"
+#include "logger.h"
 #include "absl/strings/match.h"
 #include "absl/strings/string_view.h"
 #include <asio.hpp>
@@ -9,7 +9,9 @@ namespace spectator {
 
 class SpectatordPublisher {
  public:
-  explicit SpectatordPublisher(std::string_view endpoint);
+  explicit SpectatordPublisher(
+      std::string_view endpoint,
+      std::shared_ptr<spdlog::logger> logger = DefaultLogger());
   SpectatordPublisher(const SpectatordPublisher&) = delete;
 
   void send(std::string_view measurement) { sender_(measurement); };
@@ -21,8 +23,10 @@ class SpectatordPublisher {
  private:
   void setup_unix_domain(std::string_view path);
   void setup_udp(std::string_view host_port);
+  void local_reconnect(std::string_view path);
+  void udp_reconnect(const asio::ip::udp::endpoint& endpoint);
 
-  Config config_;
+  std::shared_ptr<spdlog::logger> logger_;
   asio::io_context io_context_;
   asio::ip::udp::socket udp_socket_;
   asio::local::datagram_protocol::socket local_socket_;

--- a/spectator/registry.h
+++ b/spectator/registry.h
@@ -126,7 +126,8 @@ class base_registry {
   using timer_t = typename Types::timer_t;
   using timer_ptr = std::shared_ptr<time_t>;
 
-  explicit base_registry(logger_ptr logger = DefaultLogger()) : logger_(std::move(logger)) {}
+  explicit base_registry(logger_ptr logger = DefaultLogger())
+      : logger_(std::move(logger)) {}
 
   auto GetCounter(IdPtr id) { return state_.get_counter(std::move(id)); }
   auto GetCounter(std::string_view name, Tags tags = {}) {
@@ -282,9 +283,11 @@ class SpectatordRegistry
  public:
   using types = stateless_types<SpectatordPublisher>;
   explicit SpectatordRegistry(Config config, logger_ptr logger)
-      : base_registry<stateless<stateless_types<SpectatordPublisher>>>(std::move(logger)),
+      : base_registry<stateless<stateless_types<SpectatordPublisher>>>(
+            std::move(logger)),
         config_(std::move(config)) {
-    state_.publisher = std::make_unique<SpectatordPublisher>(config_.endpoint);
+    state_.publisher =
+        std::make_unique<SpectatordPublisher>(config_.endpoint, logger_);
   }
 
  private:


### PR DESCRIPTION
Reconnect when there are errors. Particularly important in the local
socket case where if the daemon becomes unavailable we must re-establish
the connection otherwise all future updates would be lost.