### PR TITLE
Fix sender when no valid endpoint is configured

### DIFF
--- a/spectator/publisher.cc
+++ b/spectator/publisher.cc
@@ -24,7 +24,12 @@ SpectatordPublisher::SpectatordPublisher(std::string_view endpoint,
         "Unknown endpoint: {}. Expecting: 'unix:/path/to/socket'"
         " or 'udp:hostname:port' - Will not send metrics",
         endpoint);
+    setup_nop_sender();
   }
+}
+
+void SpectatordPublisher::setup_nop_sender() {
+  sender_ = [this](std::string_view msg) { logger_->trace("{}", msg); };
 }
 
 void SpectatordPublisher::local_reconnect(std::string_view path) {

--- a/spectator/publisher.h
+++ b/spectator/publisher.h
@@ -21,6 +21,7 @@ class SpectatordPublisher {
   sender_fun sender_;
 
  private:
+  void setup_nop_sender();
   void setup_unix_domain(std::string_view path);
   void setup_udp(std::string_view host_port);
   void local_reconnect(std::string_view path);

--- a/spectator/publisher_test.cc
+++ b/spectator/publisher_test.cc
@@ -58,4 +58,11 @@ TEST(Publisher, Unix) {
   EXPECT_EQ(server.GetMessages(), expected);
 }
 
+TEST(Publisher, Nop) {
+  SpectatordPublisher publisher{""};
+  Counter c{std::make_shared<Id>("counter", Tags{}), &publisher};
+  c.Increment();
+  c.Add(2);
+}
+
 }  // namespace


### PR DESCRIPTION
This fixes a problem when the endpoint configured was not valid (i.e.
did not start with `unix:` or `udp:`, and we would end up throwing an
exception due to publisher::sender not being initialized.