### PR TITLE
fix number formatting

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -29,11 +29,11 @@ jobs:
           sudo mv bazel.gpg /etc/apt/trusted.gpg.d/
           echo "deb [arch=amd64] https://storage.googleapis.com/bazel-apt stable jdk1.8" | sudo tee /etc/apt/sources.list.d/bazel.list
           sudo add-apt-repository -y ppa:ubuntu-toolchain-r/test
-          sudo apt-get update && sudo apt-get install -y bazel binutils-dev g++-11
+          sudo apt-get update && sudo apt-get install -y bazel-5.4.0 binutils-dev g++-11
 
       - name: Build spectator-cpp
         run: |
-          bazel --output_user_root=~/.cache/bazel --batch build --config asan spectator_test spectator
+          bazel-5.4.0 --output_user_root=~/.cache/bazel --batch build --config asan spectator_test spectator
 
       - name: Test spectator-cpp
         run: |

--- a/spectator/age_gauge_test.cc
+++ b/spectator/age_gauge_test.cc
@@ -16,11 +16,12 @@ TEST(AgeGauge, Set) {
   AgeGauge g{id, &publisher};
   AgeGauge g2{id2, &publisher};
 
-  g.Set(42);
-  g2.Set(2);
-  g.Set(1);
-  std::vector<std::string> expected = {"A:gauge:42", "A:gauge2,key=val:2",
-                                       "A:gauge:1"};
+  g.Set(1671641328);
+  g2.Set(1671641028.3);
+  g.Set(0);
+  std::vector<std::string> expected = {"A:gauge:1671641328",
+                                       "A:gauge2,key=val:1671641028.3",
+                                       "A:gauge:0"};
   EXPECT_EQ(publisher.SentMessages(), expected);
 }
 

--- a/spectator/stateless_meters.h
+++ b/spectator/stateless_meters.h
@@ -1,6 +1,6 @@
 #pragma once
 #include "id.h"
-#include "absl/strings/str_cat.h"
+#include "absl/strings/str_format.h"
 #include "absl/time/time.h"
 
 namespace spectator {
@@ -46,7 +46,10 @@ class StatelessMeter {
     if (value_prefix_.empty()) {
       value_prefix_ = detail::create_prefix(*id_, Type());
     }
-    auto msg = absl::StrCat(value_prefix_, value);
+    auto msg = absl::StrFormat("%s%f", value_prefix_, value);
+    // remove trailing zeros and decimal points
+    msg.erase(msg.find_last_not_of('0') + 1, std::string::npos);
+    msg.erase(msg.find_last_not_of('.') + 1, std::string::npos);
     publisher_->send(msg);
   }
 


### PR DESCRIPTION
When setting AgeGauges to epoch seconds, such as `1671644992`, the resulting protocol line was `A:gauge:1.67164e+09`, when it is expected to be `A:gauge:1671644992`. The original AgeGauge tests were not setting large enough numbers to discover this formatting issue.

Swapping `StrCat` for `StrFormat` and stripping trailing zeroes and decimal places from the resulting number strings produces the output we want. The AgeGauge tests have been updated to use more representative numbers.

This change also locks Bazel at version 5.4.0, since there are a number of breaking changes in the 6.0.0 release.
