### PR TITLE
remove compilation database

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -1,5 +1,3 @@
-load("@com_grail_bazel_compdb//:aspects.bzl", "compilation_database")
-
 cc_library(
     name = "spectator",
     srcs = [
@@ -49,14 +47,5 @@ cc_test(
         ":spectator",
         "@com_github_bombela_backward//:backward",
         "@com_google_googletest//:gtest",
-    ],
-)
-
-compilation_database(
-    name = "spectator_compdb",
-    testonly = True,
-    targets = [
-        ":spectator",
-        ":spectator_test",
     ],
 )


### PR DESCRIPTION
The compilation_database step was causing a "conflicting artifacts" condition when running Bazel tests in CLion. When this is removed, tests run cleanly.

The original `grailbio/bazel-compilation-database` project is in maintenance mode. If something like this is needed again in the future, we can add it back.