### PR TITLE
fix MonotonicCounterUint send bug

### DIFF
--- a/spectator/monotonic_counter_uint_test.cc
+++ b/spectator/monotonic_counter_uint_test.cc
@@ -18,8 +18,8 @@ TEST(MonotonicCounterUint, Set) {
 
   c.Set(42);
   c2.Set(2);
-  c.Set(43);
-  std::vector<std::string> expected = {"U:ctr:42", "U:ctr2,key=val:2", "U:ctr:43"};
+  c.Set(-1);
+  std::vector<std::string> expected = {"U:ctr:42", "U:ctr2,key=val:2", "U:ctr:18446744073709551615"};
   EXPECT_EQ(publisher.SentMessages(), expected);
 }
 }  // namespace

--- a/spectator/stateless_meters.h
+++ b/spectator/stateless_meters.h
@@ -53,6 +53,14 @@ class StatelessMeter {
     publisher_->send(msg);
   }
 
+  void send_uint(uint64_t value) {
+    if (value_prefix_.empty()) {
+      value_prefix_ = detail::create_prefix(*id_, Type());
+    }
+    auto msg = absl::StrFormat("%s%u", value_prefix_, value);
+    publisher_->send(msg);
+  }
+
  private:
   IdPtr id_;
   Pub* publisher_;
@@ -134,7 +142,7 @@ class MonotonicCounterUint : public StatelessMeter<Pub> {
  public:
   MonotonicCounterUint(IdPtr id, Pub* publisher)
       : StatelessMeter<Pub>(std::move(id), publisher) {}
-  void Set(uint64_t amount) noexcept { this->send(amount); }
+  void Set(uint64_t amount) noexcept { this->send_uint(amount); }
 
  protected:
   std::string_view Type() override { return "U"; }


### PR DESCRIPTION
It was using the existing `send` method, which formatted the value as a float, when it needs to be formatted as a uint.