### PR TITLE
align abseil version with spectatord

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -4,7 +4,7 @@ from conan import ConanFile
 class SpectatorCppConan(ConanFile):
     settings = "os", "compiler", "build_type", "arch"
     requires = (
-        "abseil/20240722.0",
+        "abseil/20240116.2",
         "asio/1.32.0",
         "backward-cpp/1.6",
         "fmt/11.0.2",


### PR DESCRIPTION
The spectatord package declares a dependency on `protobuf/5.27.0`, which then specifies a slightly older version of `abseil`. Align these versions.