### PR TITLE
Update Config Tagging Policy

### DIFF
--- a/libs/config/config.cpp
+++ b/libs/config/config.cpp
@@ -20,6 +20,14 @@ std::unordered_map<std::string, std::string> CalculateTags(
 {
     std::unordered_map<std::string, std::string> valid_tags;
 
+    for (const auto& [fst, snd] : tags)
+    {
+        if (IsEmptyOrWhitespace(fst) == false && IsEmptyOrWhitespace(snd) == false)
+        {
+            valid_tags[fst] = snd;
+        }
+    }
+
     const char* container_name = std::getenv(ConfigConstants::EnvVarContainer);
     const char* process_name = std::getenv(ConfigConstants::EnvVarProcess);
 
@@ -38,14 +46,6 @@ std::unordered_map<std::string, std::string> CalculateTags(
         if (IsEmptyOrWhitespace(process_str) == false)
         {
             valid_tags[ConfigConstants::Process] = process_str;
-        }
-    }
-
-    for (const auto& [fst, snd] : tags)
-    {
-        if (IsEmptyOrWhitespace(fst) == false && IsEmptyOrWhitespace(snd) == false)
-        {
-            valid_tags[fst] = snd;
         }
     }
 

--- a/libs/config/test_config.cpp
+++ b/libs/config/test_config.cpp
@@ -190,12 +190,12 @@ TEST_F(ConfigTest, MergingTags)
         EXPECT_EQ(config.GetExtraTags().at("env"), "test");
     }
 
-    // Override environment variables with explicit tags
+    // Override common tags with explicit env tags
     {
-        containerGuard.setValue("test-container");
+        containerGuard.setValue("override-container");
         processGuard.unsetValue();
 
-        std::unordered_map<std::string, std::string> tags = {{"nf.container", "override-container"}};
+        std::unordered_map<std::string, std::string> tags = {{"nf.container", "test-container"}};
 
         Config config(writerConfig, tags);
 


### PR DESCRIPTION
Tags from environment variables should take precedence over tags passed to the Config.