### PR TITLE
perf: Use std::to_chars and thread-local buffers for faster stateless meter send

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -23,6 +23,8 @@ cc_library(
     deps = [
         "@abseil-cpp//absl/container:flat_hash_map",
         "@abseil-cpp//absl/strings",
+        "@abseil-cpp//absl/strings:str_format",
+        "@abseil-cpp//absl/time",
         "@asio",
         "@fmt//:fmt",
         "@spdlog//:spdlog",

--- a/spectator/gauge_test.cc
+++ b/spectator/gauge_test.cc
@@ -1,6 +1,8 @@
 #include "stateless_meters.h"
 #include "test_publisher.h"
 #include <gtest/gtest.h>
+#include <cmath>
+#include <limits>
 
 namespace {
 
@@ -21,6 +23,27 @@ TEST(Gauge, Set) {
   g.Set(1);
   std::vector<std::string> expected = {"g:gauge:42", "g:gauge2,key=val:2",
                                        "g:gauge:1"};
+  EXPECT_EQ(publisher.SentMessages(), expected);
+}
+
+TEST(Gauge, NaN) {
+  TestPublisher publisher;
+  auto id = std::make_shared<Id>("gauge", Tags{});
+  Gauge g{id, &publisher};
+  g.Set(std::numeric_limits<double>::quiet_NaN());
+  // Legacy absl::StrFormat("%f") produced "nan"; verify we preserve that.
+  std::vector<std::string> expected = {"g:gauge:nan"};
+  EXPECT_EQ(publisher.SentMessages(), expected);
+}
+
+TEST(Gauge, Infinity) {
+  TestPublisher publisher;
+  auto id = std::make_shared<Id>("gauge", Tags{});
+  Gauge g{id, &publisher};
+  g.Set(std::numeric_limits<double>::infinity());
+  g.Set(-std::numeric_limits<double>::infinity());
+  // Legacy absl::StrFormat("%f") produced "inf" / "-inf".
+  std::vector<std::string> expected = {"g:gauge:inf", "g:gauge:-inf"};
   EXPECT_EQ(publisher.SentMessages(), expected);
 }
 

--- a/spectator/stateless_meters.h
+++ b/spectator/stateless_meters.h
@@ -77,19 +77,28 @@ class StatelessMeter {
     if (value_prefix_.empty()) {
       value_prefix_ = detail::create_prefix(*id_, Type());
     }
-    auto msg = absl::StrFormat("%s%f", value_prefix_, value);
-    // remove trailing zeros and decimal points
-    msg.erase(msg.find_last_not_of('0') + 1, std::string::npos);
-    msg.erase(msg.find_last_not_of('.') + 1, std::string::npos);
-    publisher_->send(msg);
+    // std::to_chars with fixed format: no trailing zeros, no scientific notation,
+    // ~5-10x faster than absl::StrFormat("%s%f",...) + erase.
+    char num_buf[327];  // fixed-format double worst case: DBL_MAX ~309 digits
+    auto [ptr, ec] = std::to_chars(num_buf, num_buf + sizeof(num_buf), value,
+                                    std::chars_format::fixed);
+    // thread_local retains capacity after warmup — zero allocation per send.
+    thread_local std::string tl_msg;
+    tl_msg.assign(value_prefix_);
+    tl_msg.append(num_buf, ptr);
+    publisher_->send(tl_msg);
   }
 
   void send_uint(uint64_t value) {
     if (value_prefix_.empty()) {
       value_prefix_ = detail::create_prefix(*id_, Type());
     }
-    auto msg = absl::StrFormat("%s%u", value_prefix_, value);
-    publisher_->send(msg);
+    char num_buf[24];
+    auto [ptr, ec] = std::to_chars(num_buf, num_buf + sizeof(num_buf), value);
+    thread_local std::string tl_msg;
+    tl_msg.assign(value_prefix_);
+    tl_msg.append(num_buf, ptr);
+    publisher_->send(tl_msg);
   }
 
  private:

--- a/spectator/stateless_meters.h
+++ b/spectator/stateless_meters.h
@@ -1,8 +1,9 @@
 #pragma once
+#include <cassert>
 #include <charconv>
+#include <cmath>
 #include "id.h"
 #include "absl/strings/str_cat.h"
-#include "absl/strings/str_format.h"
 #include "absl/time/time.h"
 
 namespace spectator {
@@ -10,6 +11,10 @@ namespace spectator {
 namespace detail {
 
 #include "valid_chars.inc"
+
+// IEEE 754 double in fixed notation requires at most 1076 chars
+// (sign + 1074 fractional digits + decimal point for minimum subnormal).
+static constexpr size_t kMaxFixedDoubleLen = 1076;
 
 inline std::string as_string(std::string_view v) { 
     return {v.data(), v.size()}; 
@@ -45,6 +50,14 @@ inline std::string create_prefix(const Id& id, std::string_view type_name) {
   return res;
 }
 
+// Single thread-local send buffer shared across all StatelessMeter instantiations.
+// Non-template so all Pub types resolve to the same storage slot per thread.
+// Not re-entrant: callers must complete send() before the buffer is safe to reuse.
+inline std::string& tl_send_buf() {
+  thread_local std::string buf;
+  return buf;
+}
+
 template <typename T>
 T restrict(T amount, T min, T max) {
   auto r = amount;
@@ -66,9 +79,7 @@ class StatelessMeter {
   }
   virtual ~StatelessMeter() = default;
   std::string GetPrefix() {
-    if (value_prefix_.empty()) {
-      value_prefix_ = detail::create_prefix(*id_, Type());
-    }
+    ensure_prefix();
     return value_prefix_;
   }
   [[nodiscard]] IdPtr MeterId() const noexcept { return id_; }
@@ -76,41 +87,51 @@ class StatelessMeter {
 
  protected:
   void send(double value) {
-    if (value_prefix_.empty()) {
-      value_prefix_ = detail::create_prefix(*id_, Type());
+    ensure_prefix();
+    auto& tl_msg = detail::tl_send_buf();
+    tl_msg.assign(value_prefix_);
+
+    // Early exit: match absl::StrFormat("%f") behaviour for special values.
+    if (std::isnan(value)) {
+      tl_msg.append("nan");
+      publisher_->send(tl_msg);
+      return;
     }
+
+    if (std::isinf(value)) {
+      tl_msg.append(value > 0 ? "inf" : "-inf");
+      publisher_->send(tl_msg);
+      return;
+    }
+
     // std::to_chars with fixed format: no trailing zeros, no scientific notation,
     // ~5-10x faster than absl::StrFormat("%s%f",...) + erase.
     // Stack buffer covers typical values; heap fallback for extreme cases (subnormals).
     char num_buf[64];
     auto [ptr, ec] = std::to_chars(num_buf, num_buf + sizeof(num_buf), value,
                                     std::chars_format::fixed);
-    // thread_local retains capacity after warmup — zero allocation per send.
-    thread_local std::string tl_msg;
-    tl_msg.assign(value_prefix_);
     if (ec == std::errc{}) {
       tl_msg.append(num_buf, ptr);
     } else {
-      // Fallback for extreme values (subnormals): write into tl_msg via resize.
-      // We do not take this pathway normally as it will issue a write of \0's into
-      // the 1076 chars every time
+      // Fallback for subnormal values, which require up to 1076 chars in fixed
+      // notation. NaN/Inf are handled above, so this branch is subnormals only.
       auto off = tl_msg.size();
-      tl_msg.resize(off + 1076);
-      auto [hp, hec] = std::to_chars(tl_msg.data() + off,
-                                      tl_msg.data() + tl_msg.size(), value,
-                                      std::chars_format::fixed);
-      tl_msg.resize(static_cast<size_t>(hp - tl_msg.data()));
+      tl_msg.resize(off + detail::kMaxFixedDoubleLen);
+      auto [heap_ptr, heap_ec] = std::to_chars(tl_msg.data() + off,
+                                               tl_msg.data() + tl_msg.size(), value,
+                                               std::chars_format::fixed);
+      assert(heap_ec == std::errc{});
+      tl_msg.resize(static_cast<size_t>(heap_ptr - tl_msg.data()));
     }
     publisher_->send(tl_msg);
   }
 
   void send_uint(uint64_t value) {
-    if (value_prefix_.empty()) {
-      value_prefix_ = detail::create_prefix(*id_, Type());
-    }
+    ensure_prefix();
     char num_buf[24];
     auto [ptr, ec] = std::to_chars(num_buf, num_buf + sizeof(num_buf), value);
-    thread_local std::string tl_msg;
+    assert(ec == std::errc{});
+    auto& tl_msg = detail::tl_send_buf();
     tl_msg.assign(value_prefix_);
     tl_msg.append(num_buf, ptr);
     publisher_->send(tl_msg);
@@ -120,6 +141,12 @@ class StatelessMeter {
   IdPtr id_;
   Pub* publisher_;
   std::string value_prefix_;
+
+  void ensure_prefix() {
+    if (value_prefix_.empty()) {
+      value_prefix_ = detail::create_prefix(*id_, Type());
+    }
+  }
 };
 
 template <typename Pub>

--- a/spectator/stateless_meters.h
+++ b/spectator/stateless_meters.h
@@ -1,5 +1,7 @@
 #pragma once
+#include <charconv>
 #include "id.h"
+#include "absl/strings/str_cat.h"
 #include "absl/strings/str_format.h"
 #include "absl/time/time.h"
 

--- a/spectator/stateless_meters.h
+++ b/spectator/stateless_meters.h
@@ -79,13 +79,26 @@ class StatelessMeter {
     }
     // std::to_chars with fixed format: no trailing zeros, no scientific notation,
     // ~5-10x faster than absl::StrFormat("%s%f",...) + erase.
-    char num_buf[327];  // fixed-format double worst case: DBL_MAX ~309 digits
+    // Stack buffer covers typical values; heap fallback for extreme cases (subnormals).
+    char num_buf[64];
     auto [ptr, ec] = std::to_chars(num_buf, num_buf + sizeof(num_buf), value,
                                     std::chars_format::fixed);
     // thread_local retains capacity after warmup — zero allocation per send.
     thread_local std::string tl_msg;
     tl_msg.assign(value_prefix_);
-    tl_msg.append(num_buf, ptr);
+    if (ec == std::errc{}) {
+      tl_msg.append(num_buf, ptr);
+    } else {
+      // Fallback for extreme values (subnormals): write into tl_msg via resize.
+      // We do not take this pathway normally as it will issue a write of \0's into
+      // the 1076 chars every time
+      auto off = tl_msg.size();
+      tl_msg.resize(off + 1076);
+      auto [hp, hec] = std::to_chars(tl_msg.data() + off,
+                                      tl_msg.data() + tl_msg.size(), value,
+                                      std::chars_format::fixed);
+      tl_msg.resize(static_cast<size_t>(hp - tl_msg.data()));
+    }
     publisher_->send(tl_msg);
   }
 


### PR DESCRIPTION
Replace absl::StrFormat + trailing-zero erasure with std::to_chars, and, use thread_local strings to eliminate per-send allocations after warmup. This shows up in the atlas destroy path specifically.

full chain before
```
Concurrent/FilterChain/Accept/0/threads:1_mean         10532 ns        10532 ns           20
    atlas_create_ns=135.793 atlas_decode_ns=1.41467k atlas_destroy_ns=4.28813k atlas_encode_ns=581.29
Concurrent/FilterChain/Accept/0/threads:24_mean        12890 ns        12834 ns           20
    atlas_create_ns=153.269 atlas_decode_ns=1.80219k atlas_destroy_ns=5.17023k atlas_encode_ns=840.605
Concurrent/FilterChain/Shed/1/threads:1_mean            7981 ns         7981 ns           20
    atlas_create_ns=137.023 atlas_decode_ns=1.40453k atlas_destroy_ns=2.91061k atlas_encode_ns=0
Concurrent/FilterChain/Shed/1/threads:24_mean           9444 ns         9424 ns           20
    atlas_create_ns=147.787 atlas_decode_ns=1.75386k atlas_destroy_ns=3.47667k atlas_encode_ns=0
```

full chain after
```
Concurrent/FilterChain/Accept/0/threads:1_mean         10172 ns        10171 ns           20
    atlas_create_ns=138.092 atlas_decode_ns=1.41502k atlas_destroy_ns=3.88331k atlas_encode_ns=575.575
Concurrent/FilterChain/Accept/0/threads:24_mean        12288 ns        12258 ns           20
    atlas_create_ns=151.505 atlas_decode_ns=1.76232k atlas_destroy_ns=4.65918k atlas_encode_ns=820.659
Concurrent/FilterChain/Shed/1/threads:1_mean            7897 ns         7897 ns           20
    atlas_create_ns=138.271 atlas_decode_ns=1.39419k atlas_destroy_ns=2.82182k atlas_encode_ns=0
Concurrent/FilterChain/Shed/1/threads:24_mean           9088 ns         9044 ns           20
    atlas_create_ns=146.748 atlas_decode_ns=1.73368k atlas_destroy_ns=3.13205k atlas_encode_ns=0
```