### PR TITLE
Update Logging

### DIFF
--- a/spectator/registry.cpp
+++ b/spectator/registry.cpp
@@ -1,9 +1,21 @@
 #include <registry.h>
 
+// Not exposed by registry.h on purpose: keeping <logger.h> out of the public
+// header keeps spdlog and the spectator::Logger name out of consumers.
+#include <logger.h>
+
 namespace spectator {
 
+void SetLogLevel(spdlog::level::level_enum level)
+{
+    // GetLogger() yields nullptr when spdlog initialization failed.
+    if (auto* logger = Logger::GetLogger(); logger != nullptr)
+    {
+        logger->set_level(level);
+    }
+}
 
-std::pair<std::string, int> ParseUdpAddress(const std::string& address) 
+std::pair<std::string, int> ParseUdpAddress(const std::string& address)
 {
     std::regex pattern("udp://([0-9.]+):(\\d+)");
     std::smatch matches;

--- a/spectator/registry.h
+++ b/spectator/registry.h
@@ -1,10 +1,13 @@
 #pragma once
 
 #include <config.h>
-#include <logger.h>
 #include <meter_id.h>
 #include <meter_types.h>
 #include <writer.h>
+
+// Only for spdlog::level::level_enum. Deliberately not <logger.h>, which would
+// also drag in spdlog/async.h, fmt, and the spectator::Logger name.
+#include <spdlog/common.h>
 
 #include <memory>
 #include <string>
@@ -14,6 +17,11 @@
 #include <type_traits>
 
 namespace spectator {
+
+// Sets the severity threshold of the spectator logger. Lets callers adjust
+// logging without including <logger.h>, so spectator::Logger stays out of
+// consumers' namespaces. No-op if the logger failed to initialize.
+void SetLogLevel(spdlog::level::level_enum level);
 
 class Registry
 {


### PR DESCRIPTION
Removed #include <logger.h> from registry.h and added a SetLogLevel(spdlog::level::level_enum) entry point in its place, so consumers can adjust the spectator log level without pulling spectator::Logger — along with spdlog/spdlog.h, spdlog/async.h, and fmt/core.h — into every translation unit that includes a Registry. registry.cpp now includes logger.h directly for its own Logger::info calls and implements SetLogLevel, guarding against the null logger that logger.h leaves behind when spdlog initialization fails.